### PR TITLE
Fixed links to documentation

### DIFF
--- a/packages/content-api/README.md
+++ b/packages/content-api/README.md
@@ -5,7 +5,7 @@ JavaScript Client Library for the Ghost [Content API](https://ghost.org/docs/api
 
 ## Usage
 
-See https://ghost.org/docs/api/javascript/
+See https://ghost.org/docs/content-api/javascript/
 
 ## Develop
 

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -4,7 +4,7 @@ Javascript Helpers for working with the Ghost [Content API](https://docs.ghost.o
 
 ## Usage
 
-See https://docs.ghost.org/api/helpers/
+See https://docs.ghost.org/themes/helpers/
 
 ## Develop
 


### PR DESCRIPTION
https://ghost.org/docs/api/javascript/ and https://docs.ghost.org/api/helpers/ are pointing to 404, fixed with the correct URLs.