### PR TITLE
🐛 Fixed markdown url transforms of linked images

### DIFF
--- a/packages/url-utils/lib/utils/_markdown-transform.js
+++ b/packages/url-utils/lib/utils/_markdown-transform.js
@@ -2,6 +2,19 @@ const remark = require('remark');
 const footnotes = require('remark-footnotes');
 const visit = require('unist-util-visit');
 
+function replaceLast(find, replace, str) {
+    const lastIndex = str.lastIndexOf(find);
+
+    if (lastIndex === -1) {
+        return str;
+    }
+
+    const begin = str.substring(0, lastIndex);
+    const end = str.substring(lastIndex + find.length);
+
+    return begin + replace + end;
+}
+
 function markdownTransform(markdown = '', siteUrl, transformFunctions, itemPath, _options = {}) {
     const defaultOptions = {assetsOnly: false, ignoreProtocol: true};
     const options = Object.assign({}, defaultOptions, _options);
@@ -49,17 +62,30 @@ function markdownTransform(markdown = '', siteUrl, transformFunctions, itemPath,
 
     let result = markdown;
     let offsetAdjustment = 0;
+    let nestedAdjustment = 0;
 
-    replacements.forEach((replacement) => {
+    replacements.forEach((replacement, i) => {
         const original = markdown.slice(replacement.start, replacement.end);
-        const transformed = original.replace(replacement.old, replacement.new);
+        // only transform last occurrence of the old string because markdown links and images
+        // have urls at the end and we see replacements for outermost nested nodes first
+        const transformed = replaceLast(replacement.old, replacement.new, original);
 
         let before = result.slice(0, replacement.start + offsetAdjustment);
         let after = result.slice(replacement.end + offsetAdjustment, result.length);
 
         result = before + transformed + after;
 
-        offsetAdjustment = offsetAdjustment + (transformed.length - original.length);
+        // adjust offset according to new lengths
+        const nextReplacement = replacements[i + 1];
+        const adjustment = transformed.length - original.length;
+
+        if (nextReplacement && nextReplacement.start < replacement.end) {
+            // next replacement is nested, do not apply any offset adjustments until we're out of nesting
+            nestedAdjustment = nestedAdjustment + adjustment;
+        } else {
+            offsetAdjustment = offsetAdjustment + adjustment + nestedAdjustment;
+            nestedAdjustment = 0;
+        }
     });
 
     return result;

--- a/packages/url-utils/test/unit/utils/markdown-absolute-to-relative.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-absolute-to-relative.test.js
@@ -107,6 +107,14 @@ Testing <a href="/link">Inline</a> with **markdown**
             .should.equal(markdown);
     });
 
+    it('handles linked images', function () {
+        const markdown = '[![Test](http://my-ghost-blog.com/content/images/2014/01/test.jpg)](http://my-ghost-blog.com/content/images/2014/01/test.jpg)';
+
+        const result = markdownAbsoluteToRelative(markdown, siteUrl, options);
+
+        result.should.equal('[![Test](/content/images/2014/01/test.jpg)](/content/images/2014/01/test.jpg)');
+    });
+
     describe('AST parsing is skipped', function () {
         let remarkSpy, sandbox;
 

--- a/packages/url-utils/test/unit/utils/markdown-absolute-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-absolute-to-transform-ready.test.js
@@ -1,0 +1,158 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('../../utils');
+
+const fs = require('fs');
+const path = require('path');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const markdownTransform = rewire('../../../lib/utils/_markdown-transform');
+const markdownAbsoluteToTransformReady = rewire('../../../lib/utils/markdown-absolute-to-transform-ready');
+
+describe('utils: markdownAbsoluteToTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('works (demo post)', function () {
+        const transformReadyMarkdown = fs.readFileSync(path.join(__dirname, '../../fixtures/long-markdown-transform-ready.md'), 'utf8');
+        const absoluteMarkdown = fs.readFileSync(path.join(__dirname, '../../fixtures/long-markdown-absolute.md'), 'utf8');
+
+        markdownAbsoluteToTransformReady(absoluteMarkdown, 'https://demo.ghost.io/', options)
+            .should.equal(transformReadyMarkdown);
+    });
+
+    it('converts absolute URLs in markdown', function () {
+        const markdown = 'This is a [link](http://my-ghost-blog.com/link) and this is an ![](http://my-ghost-blog.com/content/images/image.png)';
+
+        markdownAbsoluteToTransformReady(markdown, siteUrl, options)
+            .should.equal('This is a [link](__GHOST_URL__/link) and this is an ![](__GHOST_URL__/content/images/image.png)');
+    });
+
+    it('converts absolute URLs in HTML', function () {
+        const markdown = `
+Testing <a href="http://my-ghost-blog.com/link">Inline</a> with **markdown**
+
+<p>
+    And block-level <img src="http://my-ghost-blog.com/content/images/image.png">
+</p>
+        `;
+
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl, options);
+
+        result.should.equal(`
+Testing <a href="__GHOST_URL__/link">Inline</a> with **markdown**
+
+<p>
+    And block-level <img src="__GHOST_URL__/content/images/image.png">
+</p>
+        `);
+    });
+
+    it('converts protocol relative `//` URLs', function () {
+        const markdown = '![](//my-ghost-blog.com/content/images/image.png)';
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl, options);
+
+        result.should.equal('![](__GHOST_URL__/content/images/image.png)');
+    });
+
+    it('skips absolute URLS in code blocks', function () {
+        const markdown = '## Testing\n\n    ![](http://my-ghost-blog.com/content/images/image.png)';
+        markdownAbsoluteToTransformReady(markdown, siteUrl, options)
+            .should.equal(markdown);
+    });
+
+    it('converts only asset URLs with assetsOnly=true option', function () {
+        const markdown = '![](http://my-ghost-blog.com/content/images/image.png) [](http://my-ghost-blog.com/not-an-asset)';
+
+        options.assetsOnly = true;
+
+        markdownAbsoluteToTransformReady(markdown, siteUrl, options)
+            .should.equal('![](__GHOST_URL__/content/images/image.png) [](http://my-ghost-blog.com/not-an-asset)');
+    });
+
+    it('retains whitespace layout', function () {
+        const markdown = `
+
+## Testing
+
+    this is a code block
+    `;
+
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl, options);
+
+        result.should.equal(`
+
+## Testing
+
+    this is a code block
+    `);
+    });
+
+    it('retains whitespace layout inside list elements', function () {
+        const markdown = '## testing\n\nmctesters\n\n- test\n- line\n- items"';
+        markdownAbsoluteToTransformReady(markdown, siteUrl, options)
+            .should.equal(markdown);
+    });
+
+    it('does not strip chars from end', function () {
+        const markdown = '<a href="https://example.com">Test</a> <a href="https://example.com/2">Test2</a> Test';
+
+        markdownAbsoluteToTransformReady(markdown, siteUrl, options)
+            .should.equal(markdown);
+    });
+
+    it('handles linked images', function () {
+        const markdown = '[![Test](http://my-ghost-blog.com/content/images/2014/01/test.jpg)](http://my-ghost-blog.com/content/images/2014/01/test.jpg)';
+
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl, options);
+
+        result.should.equal('[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/content/images/2014/01/test.jpg)');
+    });
+
+    describe('AST parsing is skipped', function () {
+        let remarkSpy, sandbox;
+
+        beforeEach(function () {
+            sandbox = sinon.createSandbox();
+            const remark = markdownTransform.__get__('remark');
+            remarkSpy = sinon.spy(remark);
+            markdownTransform.__set__('remark', remarkSpy);
+            markdownAbsoluteToTransformReady.__set__('markdownTransform', markdownTransform);
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('when markdown has no absolute URLs matching siteUrl', function () {
+            const url = 'http://my-ghost-blog.com/';
+
+            markdownAbsoluteToTransformReady('', url, options);
+            remarkSpy.called.should.be.false();
+
+            markdownAbsoluteToTransformReady('[test](#test)', url, options);
+            remarkSpy.called.should.be.false();
+
+            markdownAbsoluteToTransformReady('[test](https://example.com)', url, options);
+            remarkSpy.called.should.be.false();
+
+            markdownAbsoluteToTransformReady('[test](http://my-ghost-blog.com)', url, options);
+            remarkSpy.calledOnce.should.be.true();
+
+            // ignores protocol when ignoreProtocol: true
+            markdownAbsoluteToTransformReady('[test](https://my-ghost-blog.com)', url, options);
+            remarkSpy.calledTwice.should.be.true();
+
+            // respects protocol when ignoreProtocol: false
+            options.ignoreProtocol = false;
+            markdownAbsoluteToTransformReady('[test](https://my-ghost-blog.com)', url, options);
+            remarkSpy.calledTwice.should.be.true();
+        });
+    });
+});

--- a/packages/url-utils/test/unit/utils/markdown-relative-to-absolute.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-relative-to-absolute.test.js
@@ -101,6 +101,14 @@ Testing <a href="http://my-ghost-blog.com/link">Inline</a> with **markdown**
             .should.equal(markdown);
     });
 
+    it('handles linked images', function () {
+        const markdown = '[![Test](/content/images/2014/01/test.jpg)](/content/images/2014/01/test.jpg)';
+
+        const result = markdownRelativeToAbsolute(markdown, siteUrl, itemPath, options);
+
+        result.should.equal('[![Test](http://my-ghost-blog.com/content/images/2014/01/test.jpg)](http://my-ghost-blog.com/content/images/2014/01/test.jpg)');
+    });
+
     describe('AST parsing is skipped', function () {
         let remarkSpy, sandbox;
 

--- a/packages/url-utils/test/unit/utils/markdown-relative-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-relative-to-transform-ready.test.js
@@ -101,6 +101,40 @@ Testing <a href="__GHOST_URL__/link">Inline</a> with **markdown**
             .should.equal(markdown);
     });
 
+    it('handles linked images', function () {
+        const markdown = '[![Test](/content/images/2014/01/test.jpg)](/post)';
+
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath, options);
+
+        result.should.equal('[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/post)');
+    });
+
+    it('handles images linked to themselves', function () {
+        const markdown = '[![Test](/content/images/2014/01/test.jpg)](/content/images/2014/01/test.jpg)';
+
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath, options);
+
+        result.should.equal('[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/content/images/2014/01/test.jpg)');
+    });
+
+    it('handles linked images with further content', function () {
+        const markdown = `
+[![Test](/content/images/2014/01/test.jpg)](/post)
+[![Test](/content/images/2014/01/test.jpg)](/content/images/2014/01/test.jpg)
+Just testing
+![](/content/images/image.png) [](/just-a-link)
+        `;
+
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath, options);
+
+        result.should.equal(`
+[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/post)
+[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/content/images/2014/01/test.jpg)
+Just testing
+![](__GHOST_URL__/content/images/image.png) [](__GHOST_URL__/just-a-link)
+        `);
+    });
+
     describe('AST parsing is skipped', function () {
         let remarkSpy, sandbox;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/596

If markdown had an image that was linked to itself or another same-site URL then the markdown would become mangled due to replacement offsets not being calculated correctly.

- keep track of offset adjustments whilst looping across nested replacements and apply the overall offset adjustment once we're leaving nested nodes
  - fixes offset being incorrect when the start/end of a replacement is inside of the previous replacement)
- replace the last rather than first occurrence of the "old" string to account for replacements being in outer-to-inner order and markdown links and images having URLs at the end of a node
  - fixes images linked to themselves where "old" matches both image and link, in that situation link replacement is seen first but appears last in the text)