### PR TITLE
Dropped explicit enum from `posts.visibility`

### DIFF
--- a/packages/admin-api-schema/lib/canary/posts.json
+++ b/packages/admin-api-schema/lib/canary/posts.json
@@ -42,8 +42,7 @@
           "maxLength": 6
         },
         "visibility": {
-          "type": ["string", "null"],
-          "enum": ["public", "members", "paid"]
+          "type": ["string", "null"]
         },
         "meta_title": {
           "type": ["string", "null"],

--- a/packages/admin-api-schema/lib/v2/posts.json
+++ b/packages/admin-api-schema/lib/v2/posts.json
@@ -42,8 +42,7 @@
           "maxLength": 6
         },
         "visibility": {
-          "type": ["string", "null"],
-          "enum": ["public", "members", "paid"]
+          "type": ["string", "null"]
         },
         "meta_title": {
           "type": ["string", "null"],

--- a/packages/admin-api-schema/lib/v3/pages.json
+++ b/packages/admin-api-schema/lib/v3/pages.json
@@ -42,8 +42,7 @@
           "maxLength": 6
         },
         "visibility": {
-          "type": ["string", "null"],
-          "enum": ["public", "members", "paid"]
+          "type": ["string", "null"]
         },
         "meta_title": {
           "type": ["string", "null"],


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/581

`posts.visibility` is changing to allow an NQL filter in addition to `public`, `members`, and `paid` so a fixed enum will no longer work
