### PR TITLE
Changed the default body for a GET request to be "" instead of `{} to fix #394

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -285,7 +285,7 @@ module.exports = function GhostAdminAPI(options) {
         });
     }
 
-    function makeResourceRequest(resourceType, queryParams = {}, body = {}, method = 'GET', urlParams = {}) {
+    function makeResourceRequest(resourceType, queryParams = {}, body = "", method = 'GET', urlParams = {}) {
         return makeApiRequest({
             endpoint: endpointFor(resourceType, urlParams),
             method,


### PR DESCRIPTION
refs:  #394

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
