### PR TITLE
Added active property to products schema

### DIFF
--- a/packages/admin-api-schema/lib/canary/products.json
+++ b/packages/admin-api-schema/lib/canary/products.json
@@ -17,6 +17,9 @@
           "type": ["string", "null"],
           "maxLength": 191
         },
+        "active": {
+          "type": "boolean"
+        },
         "updated_at": {
           "strip": true
         },


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1252

The API is being updated to support an active property to archive and
unarchive Tiers (currently called products in the API).
