### PR TITLE
Added schema definitions for Tiers

### DIFF
--- a/packages/admin-api-schema/lib/canary/index.js
+++ b/packages/admin-api-schema/lib/canary/index.js
@@ -12,6 +12,8 @@ module.exports = [
     'posts-edit',
     'products-add',
     'products-edit',
+    'tiers-add',
+    'tiers-edit',
     'snippets-add',
     'snippets-edit',
     'tags-add',

--- a/packages/admin-api-schema/lib/canary/tiers-add.json
+++ b/packages/admin-api-schema/lib/canary/tiers-add.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tiers.add.canary",
+  "title": "tiers.add",
+  "description": "Schema for tiers.add",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "tiers": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "allOf": [{ "$ref": "tiers.canary#/definitions/tier" }]
+      }
+    }
+  },
+  "required": ["tiers"]
+}
+

--- a/packages/admin-api-schema/lib/canary/tiers-edit.json
+++ b/packages/admin-api-schema/lib/canary/tiers-edit.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tiers.edit.canary",
+  "title": "tiers.edit",
+  "description": "Schema for tiers.edit",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "tiers": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "allOf": [{ "$ref": "tiers.canary#/definitions/tier" }]
+      }
+    }
+  },
+  "required": ["tiers"]
+}
+

--- a/packages/admin-api-schema/lib/canary/tiers.json
+++ b/packages/admin-api-schema/lib/canary/tiers.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tiers.canary",
+  "title": "tiers",
+  "description": "Base Tier definitions",
+  "definitions": {
+    "tier": {
+      "description": "A Ghost Tier",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "maxLength": 191
+        },
+        "slug": {
+          "type": ["string", "null"],
+          "maxLength": 191
+        },
+        "welcome_page_url": {
+          "type": ["string", "null"],
+          "maxLength": 2000
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "updated_at": {
+          "strip": true
+        },
+        "created_at": {
+          "strip": true
+        },
+        "monthly_price": {
+          "$ref": "#/definitions/tier-price"
+        },
+        "yearly_price": {
+          "$ref": "#/definitions/tier-price"
+        },
+        "benefits": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/tier-benefit"
+          }
+        }
+      }
+    },
+    "tier-price": {
+      "description": "A Stripe Price associated with a Tier",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "maxLength": 24
+        },
+        "stripe_product_id": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "stripe_price_id": {
+          "type": "string",
+          "maxLength": 255
+        },
+        "nickname": {
+          "type": "string",
+          "maxLength": 50
+        },
+        "currency": {
+          "type": "string",
+          "maxLength": 3
+        },
+        "amount": {
+          "type": "number"
+        },
+        "active": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": ["recurring", "one_time"]
+        },
+        "interval": {
+          "type": ["string", "null"],
+          "enum": ["year", "month", "week", "day"]
+        },
+        "updated_at": {
+          "strip": true
+        },
+        "created_at": {
+          "strip": true
+        }
+      }
+    },
+    "tier-benefit": {
+      "description": "A Benefit associated with a Tier",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "maxLength": 24
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 191
+        },
+        "slug": {
+          "type": "string",
+          "maxLength": 191
+        },
+        "updated_at": {
+          "strip": true
+        },
+        "created_at": {
+          "strip": true
+        }
+      },
+      "anyOf": [
+        { "required": ["id"] },
+        { "required": ["name"] },
+        { "required": ["slug"] }
+      ]
+    }
+  }
+}

--- a/packages/admin-api-schema/test/api.test.js
+++ b/packages/admin-api-schema/test/api.test.js
@@ -1,7 +1,7 @@
 // Switch these lines once there are useful utils
 // const testUtils = require('./utils');
 require('./utils');
-const fs = require('fs/promises');
+const fs = require('fs');
 const path = require('path');
 const apiSchema = require('@tryghost/admin-api-schema');
 
@@ -77,7 +77,7 @@ describe('Exposes a correct API', function () {
         describe('list', function () {
             it('Returns names of all available definitions for default version', async function () {
                 const definitions = apiSchema.list();
-                const files = await fs.readdir(path.resolve(__dirname, '../lib/canary'));
+                const files = fs.readdirSync(path.resolve(__dirname, '../lib/canary'));
                 // We only export the "action" files rather than definition, e.g. posts-add.json, not posts.json
                 const exportedFiles = files.filter(file => /\w+-\w+.json/.test(file));
                 definitions.length.should.eql(exportedFiles.length);

--- a/packages/admin-api-schema/test/api.test.js
+++ b/packages/admin-api-schema/test/api.test.js
@@ -1,6 +1,8 @@
 // Switch these lines once there are useful utils
 // const testUtils = require('./utils');
 require('./utils');
+const fs = require('fs/promises');
+const path = require('path');
 const apiSchema = require('@tryghost/admin-api-schema');
 
 describe('Exposes a correct API', function () {
@@ -73,9 +75,12 @@ describe('Exposes a correct API', function () {
         });
 
         describe('list', function () {
-            it('Returns names of all available definitions for default version', function () {
+            it('Returns names of all available definitions for default version', async function () {
                 const definitions = apiSchema.list();
-                definitions.length.should.eql(19);
+                const files = await fs.readdir(path.resolve(__dirname, '../lib/canary'));
+                // We only export the "action" files rather than definition, e.g. posts-add.json, not posts.json
+                const exportedFiles = files.filter(file => /\w+-\w+.json/.test(file));
+                definitions.length.should.eql(exportedFiles.length);
                 definitions.includes('posts-add').should.equal(true);
             });
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1313

We can't easily alias endpoints in Ghost so instead we're duplicating
the controllers, validation & serializers. The current products
json-schema validation is not actually used, they'll all be deleted once
we release Tiers as GA.
