### PR TITLE
🐛 Fixed URL tranformation for inline CSS

### DIFF
--- a/packages/url-utils/lib/utils/_html-transform.js
+++ b/packages/url-utils/lib/utils/_html-transform.js
@@ -8,6 +8,18 @@ function extractSrcsetUrls(srcset = '') {
     });
 }
 
+function extractStyleUrls(style = '') {
+    const urls = [];
+    const regex = /url\(['|"]([^)]+)['|"]\)/g;
+    let match;
+
+    while ((match = regex.exec(style)) !== null) {
+        urls.push(match[1]);
+    }
+
+    return urls;
+}
+
 function htmlTransform(html = '', siteUrl, transformFunction, itemPath, _options) {
     const defaultOptions = {assetsOnly: false, secure: false};
     const options = Object.assign({}, defaultOptions, _options || {});
@@ -42,7 +54,7 @@ function htmlTransform(html = '', siteUrl, transformFunction, itemPath, _options
     }
 
     // find all of the relative url attributes that we care about
-    ['href', 'src', 'srcset'].forEach((attributeName) => {
+    ['href', 'src', 'srcset', 'style'].forEach((attributeName) => {
         htmlContent('[' + attributeName + ']').each((ix, el) => {
             // ignore <stream> elems and html inside of <code> elements
             if (el.name === 'stream' || htmlContent(el).closest('code').length) {
@@ -57,8 +69,14 @@ function htmlTransform(html = '', siteUrl, transformFunction, itemPath, _options
             el = htmlContent(el);
             const originalValue = el.attr(attributeName);
 
-            if (attributeName === 'srcset') {
-                const urls = extractSrcsetUrls(originalValue);
+            if (attributeName === 'srcset' || attributeName === 'style') {
+                let urls;
+
+                if (attributeName === 'srcset') {
+                    urls = extractSrcsetUrls(originalValue);
+                } else {
+                    urls = extractStyleUrls(originalValue);
+                }
                 const absoluteUrls = urls.map(url => transformFunction(url, siteUrl, itemPath, options));
                 let transformedValue = originalValue;
 

--- a/packages/url-utils/test/unit/utils/html-absolute-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/html-absolute-to-transform-ready.test.js
@@ -190,6 +190,50 @@ describe('utils: htmlAbsoluteToTransformReady()', function () {
         /* eslint-enable no-irregular-whitespace */
     });
 
+    describe('css support', function () {
+        it('converts background-image', function () {
+            let html = `
+                <div style="background-image: url('http://my-ghost-blog.com/content/images/elva-fairy-320w.jpg')"></div>
+            `;
+
+            let result = htmlAbsoluteToTransformReady(html, siteUrl, options);
+
+            result.should.eql(`
+                <div style="background-image: url('__GHOST_URL__/content/images/elva-fairy-320w.jpg')"></div>
+            `);
+        });
+
+        it('converts background image with multiple values', function () {
+            let html = `
+            <div style="background: transparent url('https://ghost.local/content/images/2022/03/68omdg.png') 50% 50% cover no-repeat;">
+            </div>`;
+
+            let result = htmlAbsoluteToTransformReady(html, siteUrl, options);
+
+            result.should.eql(`
+            <div style="background: transparent url('https://ghost.local/content/images/2022/03/68omdg.png') 50% 50% cover no-repeat;">
+            </div>`);
+        });
+
+        it('converts background-image with multiple urls', function () {
+            let html = `
+                <div style="background-image:
+                        url('http://my-ghost-blog.com/content/images/elva-fairy-320w.jpg'),
+                        url('http://my-ghost-blog.com/content/images/elva-fairy-480w.jpg')">
+                </div>
+            `;
+
+            let result = htmlAbsoluteToTransformReady(html, siteUrl, options);
+
+            result.should.eql(`
+                <div style="background-image:
+                        url('__GHOST_URL__/content/images/elva-fairy-320w.jpg'),
+                        url('__GHOST_URL__/content/images/elva-fairy-480w.jpg')">
+                </div>
+            `);
+        });
+    });
+
     describe('DOM parsing is skipped', function () {
         let cheerioLoadSpy, rewireRestore;
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/14344

- The html-transformer did not take into account new type of the URL transformation that was added with Ghost's video card.
- The video card uses inline css style with "background: url(..." to display a custom thumbnail. This means we need to process the "styles" attribute to catch use of site's URL and substitute them with `__GHOST_URL__`. This allows to export and import video cards under different site URLs.

@kevinansfield there was a bug spotted in the referenced issue and I think it requires us to start processing the "styles" attribute. I haven't touched this part of the codebase, wanted to hear your opinion around performance testing (adding this code will add overhead to transform html on each request). I might be missing some other aspects, so happy to hear out your opinion on this fix. 

Also, was asking myself if a valid solution would be to avoid using styles in combination with `url(...)`, so we have less to process. But I think once the pandora box has been opened we just need to deal with it. 

I addition to this fix we should probably add a migration to 5.0 that would go over html transformation in a loop :thinking: 

Thanks for your time!