### PR TITLE
🐛 Fix body length limit when uploading themes

### DIFF
--- a/packages/admin-api/lib/index.js
+++ b/packages/admin-api/lib/index.js
@@ -30,6 +30,7 @@ module.exports = function GhostAdminAPI(options) {
                 data,
                 headers,
                 maxContentLength: Infinity,
+                maxBodyLength: Infinity,
                 paramsSerializer(parameters) {
                     return Object.keys(parameters).reduce((parts, key) => {
                         const val = encodeURIComponent([].concat(parameters[key]).join(','));


### PR DESCRIPTION
My theme deploys began failing last week with the axios error described in this issue: https://github.com/TryGhost/SDK/issues/195

It turns out that axios now requires `maxBodyLength` to be the property we use in config to remove the upload limit. 

I haven't been able to pin down exactly why or when this config changed, though it might be connected to this recent pull request introducing the separate `maxBodyLength` option https://github.com/axios/axios/pull/2781

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
