### PR TITLE
🐛 Fixed ReDoS susceptible regexs

### DIFF
--- a/packages/helpers/lib/utils/count-images.js
+++ b/packages/helpers/lib/utils/count-images.js
@@ -12,5 +12,5 @@ export default function countImages(html) {
     if (Object.prototype.hasOwnProperty.call(html, 'string')) {
         html = html.string;
     }
-    return (html.match(/<img(.|\n)*?>/g) || []).length;
+    return (html.match(/<img("[^"]*"|'[^']*'|[^'">])+\/?>/g) || []).length;
 }

--- a/packages/helpers/lib/utils/count-words.js
+++ b/packages/helpers/lib/utils/count-words.js
@@ -15,7 +15,7 @@ export default function countWords(text) {
         text = text.string;
     }
 
-    text = text.replace(/<(.|\n)*?>/g, ' '); // strip any HTML tags
+    text = text.replace(/<("[^"]*"|'[^']*'|[^'">])+\/?>/g, ' '); // strip any HTML tags
 
     const pattern = /[a-zA-ZÀ-ÿ0-9_\u0392-\u03c9\u0410-\u04F9]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/3544

The regexs for counting words and counting images were susceptible to ReDoS and could be problematic in Ghost when the a post's HTML contains a tag with a very large attribute (i.e an image src being a base64 encoded image). This commit tweaks these regexs to make them more efficient and circumvent the problem.
