### PR TITLE
Resolved Invalid test cases for slugify

### DIFF
--- a/packages/string/test/slugify.test.js
+++ b/packages/string/test/slugify.test.js
@@ -43,7 +43,7 @@ describe('Slugify', function () {
     });
 
     it('should remove control characters', function () {
-        var result = slugify('control:\x07notcontrol:\xB5');
+        var result = slugify('control:\x07notcontrol:\u00B5');
         result.should.equal('control-notcontrol-u');
     });
 

--- a/packages/string/test/stripInvisibleChars.test.js
+++ b/packages/string/test/stripInvisibleChars.test.js
@@ -9,7 +9,7 @@ describe('Strip Invisible Chars', function () {
     });
 
     it('should remove control characters', function () {
-        var result = stripInvisibleChars('control:\x07notcontrol:\xB5');
+        var result = stripInvisibleChars('control:\x07notcontrol:\u00B5');
         result.should.equal('control:notcontrol:µ');
     });
 


### PR DESCRIPTION
closes #212

-Replaced invalid escape sequence with the required unicode escape sequence.

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test` and `yarn lint`)

