### PR TITLE
Update Istanbul timezone

### DIFF
--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -120,8 +120,8 @@ const timezoneData: {name: string; label: string}[] = [
         label: '(GMT +1:00) West Central Africa'
     },
     {
-        name: 'Europe/Istanbul',
-        label: '(GMT +2:00) Athens, Beirut, Bucharest, Istanbul'
+        name: 'Europe/Athens',
+        label: '(GMT +2:00) Athens, Beirut, Bucharest'
     },
     {
         name: 'Africa/Cairo',
@@ -150,6 +150,10 @@ const timezoneData: {name: string; label: string}[] = [
     {
         name: 'Asia/Riyadh',
         label: '(GMT +3:00) Kuwait, Nairobi, Riyadh'
+    },
+    {
+        name: 'Europe/Istanbul',
+        label: '(GMT +3:00) Istanbul, Ankara'
     },
     {
         name: 'Europe/Moscow',


### PR DESCRIPTION
Turkish time zone is set to GMT+3[^1] since 2018[^2]. Current label indicates old state.

[^1]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
[^2]: https://en.wikipedia.org/wiki/Time_in_Turkey
