### PR TITLE
Added `status` field to the image schema

### DIFF
--- a/packages/admin-api-schema/lib/schemas/images.json
+++ b/packages/admin-api-schema/lib/schemas/images.json
@@ -16,6 +16,11 @@
         "ref": {
           "type": ["string", "null"],
           "maxLength": 2000
+        },
+        "status": {
+          "type": "string",
+          "enum": ["new", "edited"],
+          "default": "new"
         }
       }
     }


### PR DESCRIPTION
refs [ENG-1260](https://linear.app/tryghost/issue/ENG-1260/🔒-redacting-pictures-in-pintura-leaves-easily-findable-original-image)

Added `status` field to the image schema to track if an image uploaded is a new image or an edited version of an existing image