### PR TITLE
Added support for more mastodon handles

### DIFF
--- a/packages/social-urls/lib/index.js
+++ b/packages/social-urls/lib/index.js
@@ -40,8 +40,33 @@ module.exports.bluesky = function bluesky(username) {
  * @returns {string}
  */
 module.exports.mastodon = function mastodon(username) {
-    // Mastodon stores full URL without https://, just prepend protocol
-    return 'https://' + username;
+    // Remove any leading @ symbols from the username
+    username = username.replace(/^@+/, '');
+
+    // Check if the input is in @username@instance format
+    if (username.includes('@') && !username.includes('/')) {
+        const [user, instance] = username.split('@');
+        return `https://${instance}/@${user}`;
+    }
+
+    // Check if the input is in instance/@username format
+    if (username.includes('/@')) {
+        return `https://${username}`;
+    }
+
+    // Check if the input is in hostInstance/@username@userInstance format
+    if (username.includes('/@') && username.includes('@', username.indexOf('/@') + 1)) {
+        return `https://${username}`;
+    }
+
+    // If we have a simple instance/username format
+    if (username.includes('/')) {
+        const [instance, user] = username.split('/');
+        return `https://${instance}/@${user}`;
+    }
+
+    // Default case: assume it's a local handle on the instance
+    return `https://${username}`;
 };
 
 /**

--- a/packages/social-urls/test/urls.test.js
+++ b/packages/social-urls/test/urls.test.js
@@ -99,6 +99,31 @@ describe('lib/social: urls', function () {
         it('should handle subdomains in instance URLs', function () {
             social.mastodon('eu.mastodon.green/@eco').should.eql('https://eu.mastodon.green/@eco');
         });
+
+        // New test cases for different URL formats
+        it('should handle @username@instance format', function () {
+            social.mastodon('@example@indieweb.social').should.eql('https://indieweb.social/@example');
+        });
+
+        it('should handle instance/@username format', function () {
+            social.mastodon('mastodon.social/@example').should.eql('https://mastodon.social/@example');
+        });
+
+        it('should handle hostInstance/@username@userInstance format', function () {
+            social.mastodon('mastodon.xyz/@Flipboard@flipboard.social').should.eql('https://mastodon.xyz/@Flipboard@flipboard.social');
+        });
+
+        it('should handle same instance format with @username@instance', function () {
+            social.mastodon('@user@mastodon.social').should.eql('https://mastodon.social/@user');
+        });
+
+        it('should handle same instance format with instance/@username', function () {
+            social.mastodon('mastodon.social/@user').should.eql('https://mastodon.social/@user');
+        });
+
+        it('should handle different instances format', function () {
+            social.mastodon('mastodon.social/@user@other.social').should.eql('https://mastodon.social/@user@other.social');
+        });
     });
 
     describe('tiktok', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-414/mastodon-validation-bug

- Enhanced mastodon function in social-urls/lib/index.js to support:
  - `@username@instance` format
  - `instance/@username` format
  - `hostInstance/@username@userInstance` format
  - Simple `instance/username` format
- Removed leading @ symbols from usernames
- Added test cases in urls.test.js to verify new Mastodon handle formats