### PR TITLE
Added support for X in social-urls

### DIFF
--- a/packages/social-urls/lib/index.js
+++ b/packages/social-urls/lib/index.js
@@ -7,6 +7,9 @@ module.exports.twitter = function twitter(username) {
     return 'https://x.com/' + username.replace(/^@/, '');
 };
 
+// Alias for twitter to support X
+module.exports.x = module.exports.twitter;
+
 /**
  * @param {string} username
  * @returns {string}

--- a/packages/social-urls/test/urls.test.js
+++ b/packages/social-urls/test/urls.test.js
@@ -11,6 +11,10 @@ describe('lib/social: urls', function () {
         should.exist(social.twitter);
     });
 
+    it('should have a x url function', function () {
+        should.exist(social.x);
+    });
+
     it('should have a facebook url function', function () {
         should.exist(social.facebook);
     });
@@ -50,6 +54,16 @@ describe('lib/social: urls', function () {
 
         it('should return a url without an @ sign if one is provided', function () {
             social.twitter('myusername').should.eql('https://x.com/myusername');
+        });
+    });
+
+    describe('x', function () {
+        it('should return a correct concatenated URL', function () {
+            social.x('@myusername').should.eql('https://x.com/myusername');
+        });
+
+        it('should return a url without an @ sign if one is provided', function () {
+            social.x('myusername').should.eql('https://x.com/myusername');
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-415/support-using-x-in-place-of-twitter

- Added X as an alias so that it can be used without breaking compatibility with Twitter