### PR TITLE
Fixed ESM imports

### DIFF
--- a/packages/referrer-parser/package.json
+++ b/packages/referrer-parser/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Simple library for parsing referrer URLs",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
no ref

Imports were not finding the right file and were instead defaulting to the ESM version, causing CJS to fail.