### PR TITLE
Reorder exports in package.json

### DIFF
--- a/packages/referrer-parser/package.json
+++ b/packages/referrer-parser/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
no ref

Types wouldn't get hit because it was after both require and import. This shouldn't be an issue as there's other handling for types, but clears up a build warning.