### PR TITLE
Updated LinkedIn url building for different profile types

### DIFF
--- a/packages/social-urls/lib/index.js
+++ b/packages/social-urls/lib/index.js
@@ -80,6 +80,10 @@ module.exports.instagram = function instagram(username) {
  * @returns {string}
  */
 module.exports.linkedin = function linkedin(username) {
-    // LinkedIn URLs use /in/, stored without @
-    return 'https://www.linkedin.com/in/' + username;
+    // LinkedIn URLs use in/, company/, school/, or pub/ stored as-is
+    const pathTypes = ['in/', 'company/', 'school/', 'pub/'];
+    // If username doesn't start with one of those, default to in/
+    const endOfUrl = pathTypes.some(pathType => username.startsWith(pathType)) ? username : 'in/' + username;
+
+    return 'https://www.linkedin.com/' + endOfUrl;
 };

--- a/packages/social-urls/test/urls.test.js
+++ b/packages/social-urls/test/urls.test.js
@@ -154,12 +154,28 @@ describe('lib/social: urls', function () {
     });
 
     describe('linkedin', function () {
-        it('should return a correct concatenated URL', function () {
-            social.linkedin('myusername').should.eql('https://www.linkedin.com/in/myusername');
+        it('should return a correct concatenated URL for personal profile', function () {
+            social.linkedin('in/myusername').should.eql('https://www.linkedin.com/in/myusername');
         });
 
-        it('should handle usernames with periods, hyphens, and underscores', function () {
-            social.linkedin('john.smith-123').should.eql('https://www.linkedin.com/in/john.smith-123');
+        it('should return a correct concatenated URL for company profile', function () {
+            social.linkedin('company/mycompany').should.eql('https://www.linkedin.com/company/mycompany');
+        });
+
+        it('should return a correct concatenated URL for school profile', function () {
+            social.linkedin('school/myschool').should.eql('https://www.linkedin.com/school/myschool');
+        });
+
+        it('should return a correct concatenated URL for a legacy pub profile', function () {
+            social.linkedin('pub/johnsmith/12/34/567').should.eql('https://www.linkedin.com/pub/johnsmith/12/34/567');
+        });
+
+        it('should handle usernames with hyphens', function () {
+            social.linkedin('in/john-smith-123').should.eql('https://www.linkedin.com/in/john-smith-123');
+        });
+
+        it('should default to in/ when username does not start with in/, company/, school/, or pub/', function () {
+            social.linkedin('myusername').should.eql('https://www.linkedin.com/in/myusername');
         });
     });
 });


### PR DESCRIPTION
ref  https://linear.app/ghost/issue/ENG-2409/not-possible-to-add-company-linkedin-profile-to-staff-member

- Updates the LinkedIn url helper so that if a user has a company, school, or pub link, it gets built properly instead of prepending with `in/`
- If a username is stored without any of those, it will still prepend `in/` to build a proper link
