### PR TITLE
✨ Added v6 support to Admin-API library

### DIFF
--- a/packages/admin-api/lib/admin-api.js
+++ b/packages/admin-api/lib/admin-api.js
@@ -7,9 +7,9 @@ const token = require('./token');
 const packageInfo = require('../package.json');
 const packageVersion = packageInfo.version;
 
-// NOTE: bump this default when Ghost v5 is released
-const defaultAcceptVersionHeader = 'v5.0';
-const supportedVersions = ['v2', 'v3', 'v4', 'v5', 'canary'];
+// NOTE: bump this default when major versions are released
+const defaultAcceptVersionHeader = 'v6.0';
+const supportedVersions = ['v2', 'v3', 'v4', 'v5', 'v6', 'canary'];
 const packageName = '@tryghost/admin-api';
 
 /**
@@ -22,14 +22,15 @@ const packageName = '@tryghost/admin-api';
 const resolveAPIPrefix = (version) => {
     let prefix;
 
-    // NOTE: the "version.match(/^v5\.\d+/)" expression should be changed to "version.match(/^v\d+\.\d+/)" once Ghost v5 is out
-    if (version === 'v5' || version === undefined || version.match(/^v5\.\d+/)) {
-        prefix = `/admin/`;
-    } else if (version.match(/^v\d+\.\d+/)) {
-        const versionPrefix = /^(v\d+)\.\d+/.exec(version)[1];
+    // Only v2, v3, v4, and canary need version prefixes in the URL
+    if (version === 'v2' || version === 'v3' || version === 'v4' || version === 'canary') {
+        prefix = `/${version}/admin/`;
+    } else if (version && version.match(/^v[2-4]\.\d+/)) {
+        const versionPrefix = /^(v[2-4])\.\d+/.exec(version)[1];
         prefix = `/${versionPrefix}/admin/`;
     } else {
-        prefix = `/${version}/admin/`;
+        // Default for v5+, v6, undefined, etc. - no version prefix
+        prefix = `/admin/`;
     }
 
     return prefix;

--- a/packages/admin-api/test/admin-api-test/v6.test.js
+++ b/packages/admin-api/test/admin-api-test/v6.test.js
@@ -1,0 +1,32 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('../utils');
+const should = require('should');
+const sinon = require('sinon');
+
+const GhostAdminAPI = require('../../lib/admin-api');
+
+describe('GhostAdminAPI v6', function () {
+    it('uses unversioned URL path and correct Accept-Version header', async function () {
+        const makeRequestStub = sinon.stub().returns(Promise.resolve({
+            posts: []
+        }));
+
+        const api = new GhostAdminAPI({
+            version: 'v6.0',
+            url: 'http://ghost.local',
+            key: '5c73def7a21ad85eda5d4faa:d9a3e5b2d6c2a4afb094655c4dc543220be60b3561fa9622e3891213cb4357d0',
+            makeRequest: makeRequestStub
+        });
+
+        await api.posts.browse();
+
+        makeRequestStub.calledOnce.should.be.true();
+
+        // v6 should use unversioned URL path (no /v6/ prefix)
+        should.equal(makeRequestStub.args[0][0].url, 'http://ghost.local/ghost/api/admin/posts/');
+
+        // v6 should send Accept-Version header as v6.0
+        should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
+    });
+});

--- a/packages/admin-api/test/lib/admin-api.test.js
+++ b/packages/admin-api/test/lib/admin-api.test.js
@@ -239,7 +239,7 @@ describe('GhostAdminAPI general', function () {
             await api.config.read();
 
             makeRequestStub.calledOnce.should.be.true();
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], `GhostAdminSDK/${packageVersion}`);
             should.equal(generateTokenSpy.args[0][0], '5c73def7a21ad85eda5d4faa:d9a3e5b2d6c2a4afb094655c4dc543220be60b3561fa9622e3891213cb4357d0');
             should.equal(generateTokenSpy.args[0][1], '/canary/admin/');
@@ -285,7 +285,7 @@ describe('GhostAdminAPI general', function () {
             await api.config.read();
 
             makeRequestStub.calledOnce.should.be.true();
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], `GhostAdminSDK/${packageVersion}`);
             should.equal(generateTokenSpy.args[0][0], '5c73def7a21ad85eda5d4faa:d9a3e5b2d6c2a4afb094655c4dc543220be60b3561fa9622e3891213cb4357d0');
             should.equal(generateTokenSpy.args[0][1], '/admin/');
@@ -309,7 +309,7 @@ describe('GhostAdminAPI general', function () {
             await api.config.read();
 
             makeRequestStub.calledOnce.should.be.true();
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], undefined);
             should.equal(generateTokenSpy.args[0][0], '5c73def7a21ad85eda5d4faa:d9a3e5b2d6c2a4afb094655c4dc543220be60b3561fa9622e3891213cb4357d0');
             should.equal(generateTokenSpy.args[0][1], '/admin/');
@@ -333,7 +333,7 @@ describe('GhostAdminAPI general', function () {
             await api.config.read();
 
             makeRequestStub.calledOnce.should.be.true();
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], 'Custom Value');
             should.equal(generateTokenSpy.args[0][0], '5c73def7a21ad85eda5d4faa:d9a3e5b2d6c2a4afb094655c4dc543220be60b3561fa9622e3891213cb4357d0');
             should.equal(generateTokenSpy.args[0][1], '/admin/');


### PR DESCRIPTION
no issue

- adds `v6` to supported versions list
- updates URL prefixing function to ensure `v6` doesn't result in a versioned URL
