### PR TITLE
✨ Added v6 support to Content-API library

### DIFF
--- a/packages/content-api/lib/content-api.js
+++ b/packages/content-api/lib/content-api.js
@@ -6,8 +6,8 @@ const USER_AGENT_DEFAULT = true;
 
 const packageVersion = packageInfo.version;
 
-const defaultAcceptVersionHeader = 'v5.0';
-const supportedVersions = ['v2', 'v3', 'v4', 'v5', 'canary'];
+const defaultAcceptVersionHeader = 'v6.0';
+const supportedVersions = ['v2', 'v3', 'v4', 'v5', 'v6', 'canary'];
 const name = '@tryghost/content-api';
 
 /**
@@ -20,14 +20,15 @@ const name = '@tryghost/content-api';
 const resolveAPIPrefix = (version) => {
     let prefix;
 
-    // NOTE: the "version.match(/^v5\.\d+/)" expression should be changed to "version.match(/^v\d+\.\d+/)" once Ghost v5 is out
-    if (version === 'v5' || version === undefined || version.match(/^v5\.\d+/)) {
-        prefix = `/content/`;
-    } else if (version.match(/^v\d+\.\d+/)) {
-        const versionPrefix = /^(v\d+)\.\d+/.exec(version)[1];
+    // Only v2, v3, v4, and canary need version prefixes in the URL
+    if (version === 'v2' || version === 'v3' || version === 'v4' || version === 'canary') {
+        prefix = `/${version}/content/`;
+    } else if (version && version.match(/^v[2-4]\.\d+/)) {
+        const versionPrefix = /^(v[2-4])\.\d+/.exec(version)[1];
         prefix = `/${versionPrefix}/content/`;
     } else {
-        prefix = `/${version}/content/`;
+        // Default for v5, v6, undefined, etc. - no version prefix
+        prefix = `/content/`;
     }
 
     return prefix;

--- a/packages/content-api/test/content-api-test/content-api.test.js
+++ b/packages/content-api/test/content-api-test/content-api.test.js
@@ -102,7 +102,7 @@ describe('GhostContentApi', function () {
 
             makeRequestStub.calledOnce.should.be.true();
             should.equal(makeRequestStub.args[0][0].url, 'http://ghost.local/ghost/api/canary/content/settings/');
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], `GhostContentSDK/${packageVersion}`);
         });
 
@@ -211,7 +211,7 @@ describe('GhostContentApi', function () {
             await api.settings.browse();
 
             makeRequestStub.calledOnce.should.be.true();
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], `GhostContentSDK/${packageVersion}`);
         });
 
@@ -234,7 +234,7 @@ describe('GhostContentApi', function () {
 
             makeRequestStub.calledOnce.should.be.true();
             should.equal(makeRequestStub.args[0][0].url, 'http://ghost.local/ghost/api/canary/content/settings/');
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], undefined);
         });
 
@@ -257,7 +257,7 @@ describe('GhostContentApi', function () {
 
             makeRequestStub.calledOnce.should.be.true();
             should.equal(makeRequestStub.args[0][0].url, 'http://ghost.local/ghost/api/canary/content/settings/');
-            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v5.0');
+            should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
             should.equal(makeRequestStub.args[0][0].headers['User-Agent'], 'I_LOVE_CUSTOM_THINGS');
         });
     });

--- a/packages/content-api/test/content-api-test/v6.test.js
+++ b/packages/content-api/test/content-api-test/v6.test.js
@@ -1,0 +1,30 @@
+const should = require('should');
+const sinon = require('sinon');
+
+const GhostContentApi = require('../../cjs/content-api');
+const packageJSON = require('../../package.json');
+const packageVersion = packageJSON.version;
+
+describe('GhostContentApi v6', function () {
+    it('Uses non-versioned URL and correct Accept-Version header for v6.0', async function () {
+        const makeRequestStub = sinon.stub().returns(Promise.resolve({
+            data: {
+                settings: {}
+            }
+        }));
+
+        const api = new GhostContentApi({
+            version: 'v6.0',
+            url: 'http://ghost.local',
+            key: '0123456789abcdef0123456789',
+            makeRequest: makeRequestStub
+        });
+
+        await api.settings.browse();
+
+        makeRequestStub.calledOnce.should.be.true();
+        should.equal(makeRequestStub.args[0][0].url, 'http://ghost.local/ghost/api/content/settings/');
+        should.equal(makeRequestStub.args[0][0].headers['Accept-Version'], 'v6.0');
+        should.equal(makeRequestStub.args[0][0].headers['User-Agent'], `GhostContentSDK/${packageVersion}`);
+    });
+});


### PR DESCRIPTION
no issue

- adds `v6` to supported versions list
- updates URL prefixing function to ensure `v6` doesn't result in a versioned URL
