### PR TITLE
Fixes various inconsistencies and outdated mappings in timezone data

### DIFF
--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -12,13 +12,13 @@ const timezoneData: {name: string; label: string}[] = [
         label: '(GMT -9:00) Alaska'
     },
     {
-        name: 'America/Mazatlan',
-        label: '(GMT -7:00) La Paz, Mazatlan'
-    }, 
-    {
         name: 'America/Los_Angeles',
         label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana'
     },
+    {
+        name: 'America/Mazatlan',
+        label: '(GMT -7:00) La Paz, Mazatlan'
+    }, 
     {
         name: 'America/Phoenix',
         label: '(GMT -7:00) Arizona'

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -201,7 +201,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'Asia/Kathmandu',
-        label: '(GMT +5:45) Katmandu'
+        label: '(GMT +5:45) Kathmandu'
     },
     
     {

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -13,7 +13,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'America/Mazatlan',
-        label: '(GMT -8:00) La Paz, Mazatlan'
+        label: '(GMT -7:00) La Paz, Mazatlan'
     }, 
     {
         name: 'America/Los_Angeles',
@@ -30,7 +30,7 @@ const timezoneData: {name: string; label: string}[] = [
     {
         name: 'America/Chihuahua',
         label: '(GMT -6:00) Chihuahua'
-    }
+    },
     {
         name: 'America/Costa_Rica',
         label: '(GMT -6:00) Central America'

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -12,8 +12,12 @@ const timezoneData: {name: string; label: string}[] = [
         label: '(GMT -9:00) Alaska'
     },
     {
+        name: 'America/Tijuana',
+        label: '(GMT -8:00) Tijuana'
+    },
+    {
         name: 'America/Los_Angeles',
-        label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana'
+        label: '(GMT -8:00) Pacific Time (US & Canada)'
     },
     {
         name: 'America/Mazatlan',

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -12,9 +12,9 @@ const timezoneData: {name: string; label: string}[] = [
         label: '(GMT -9:00) Alaska'
     },
     {
-        name: 'America/Tijuana',
-        label: '(GMT -8:00) Chihuahua, La Paz, Mazatlan'
-    },
+        name: 'America/Mazatlan',
+        label: '(GMT -8:00) La Paz, Mazatlan'
+    }, 
     {
         name: 'America/Los_Angeles',
         label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana'
@@ -27,6 +27,10 @@ const timezoneData: {name: string; label: string}[] = [
         name: 'America/Denver',
         label: '(GMT -7:00) Mountain Time (US & Canada)'
     },
+    {
+        name: 'America/Chihuahua',
+        label: '(GMT -6:00) Chihuahua'
+    }
     {
         name: 'America/Costa_Rica',
         label: '(GMT -6:00) Central America'
@@ -57,7 +61,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'America/Caracas',
-        label: '(GMT -4:00) Caracas, La Paz'
+        label: '(GMT -4:00) Caracas, La Paz, Georgetown'
     },
     {
         name: 'America/Halifax',
@@ -73,7 +77,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'America/Argentina/Buenos_Aires',
-        label: '(GMT -3:00) Buenos Aires, Brasilia, Georgetown'
+        label: '(GMT -3:00) Buenos Aires, Brasilia'
     },
     {
         name: 'America/Noronha',
@@ -176,6 +180,10 @@ const timezoneData: {name: string; label: string}[] = [
         label: '(GMT +4:30) Kabul'
     },
     {
+        name: 'Asia/Almaty',
+        label: '(GMT +5:00) Almaty, Astana'
+    },
+    {
         name: 'Asia/Karachi',
         label: '(GMT +5:00) Islamabad, Karachi, Tashkent'
     },
@@ -185,23 +193,24 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'Asia/Kolkata',
-        label: '(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi'
+        label: '(GMT +5:30) Chennai, Kolkata, Mumbai, New Delhi'
+    },
+    {
+        name: 'Asia/Colombo',
+        label: '(GMT +5:30) Colombo, Sri Jayawardenepura'
     },
     {
         name: 'Asia/Kathmandu',
         label: '(GMT +5:45) Katmandu'
     },
-    {
-        name: 'Asia/Almaty',
-        label: '(GMT +6:00) Almaty, Novosibirsk'
-    },
+    
     {
         name: 'Asia/Dhaka',
-        label: '(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura'
+        label: '(GMT +6:00) Dhaka'
     },
     {
         name: 'Asia/Rangoon',
-        label: '(GMT +6:30) Rangoon'
+        label: '(GMT +6:30) Yangon (Rangoon)'
     },
     {
         name: 'Asia/Bangkok',
@@ -209,7 +218,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'Asia/Krasnoyarsk',
-        label: '(GMT +7:00) Krasnoyarsk'
+        label: '(GMT +7:00) Krasnoyarsk,Novosibirsk'
     },
     {
         name: 'Asia/Hong_Kong',
@@ -217,7 +226,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'Asia/Irkutsk',
-        label: '(GMT +8:00) Irkutsk, Ulaan Bataar'
+        label: '(GMT +8:00) Irkutsk, Ulaanbaatar'
     },
     {
         name: 'Asia/Singapore',

--- a/packages/timezone-data/src/index.ts
+++ b/packages/timezone-data/src/index.ts
@@ -22,7 +22,7 @@ const timezoneData: {name: string; label: string}[] = [
     {
         name: 'America/Mazatlan',
         label: '(GMT -7:00) La Paz, Mazatlan'
-    }, 
+    },
     {
         name: 'America/Phoenix',
         label: '(GMT -7:00) Arizona'
@@ -207,7 +207,6 @@ const timezoneData: {name: string; label: string}[] = [
         name: 'Asia/Kathmandu',
         label: '(GMT +5:45) Kathmandu'
     },
-    
     {
         name: 'Asia/Dhaka',
         label: '(GMT +6:00) Dhaka'
@@ -222,7 +221,7 @@ const timezoneData: {name: string; label: string}[] = [
     },
     {
         name: 'Asia/Krasnoyarsk',
-        label: '(GMT +7:00) Krasnoyarsk,Novosibirsk'
+        label: '(GMT +7:00) Krasnoyarsk, Novosibirsk'
     },
     {
         name: 'Asia/Hong_Kong',


### PR DESCRIPTION
Implements the suggested fixes in https://github.com/TryGhost/Ghost/issues/24536.

Ghost admin tests are updated in https://github.com/TryGhost/Ghost/pull/24562.

Summary of changes:

1. Removes the redundant `America/Tijuana` entry, as `Tijuana` is already [covered](https://github.com/TryGhost/SDK/blob/b5c29510af8c1af9a11f593f91f5834ebf821594/packages/timezone-data/src/index.ts#L20) under Pacific Time.
2. Create a new GMT-6 entry for `Chihuahua` using `America/Chihuahua`, as the current timezone mapping is incorrect.
3. Create a new GMT-7 entry for `La Paz` and `Mazatlan` using `America/Mazatlan`, as the current timezone mapping is incorrect.
4. Group `Georgetown` under GMT-4, along with Caracas and La Paz. All three cities observe GMT-4 throughout the year, and don't observe DST.
5. Combine `Almaty` and `Astana` under a new timezone identifier, as the current timezone mapping is incorrect.
6. Update `Calcutta` (former city name) to the current name `Kolkata`.
7. Update `Rangoon` (former city name) to the current name `Yangon`.
8. Update `Katmandu` (former city name) to the current name `Kathmandu`.
9. Update `Ulaan Bataar` to the correct name `Ulaanbataar`.
10. Create a new GMT+5:30 entry for Sri Jayawardenepura using `Asia/Colombo`, as the current timezone mapping is incorrect.
11. Move Novosibirsk to GMT+7, and group it with Krasnoyarsk, both of which observe the same timezone throughout the year.



