### PR TITLE
🎨 Removed excessive new lines and improved header formatting in plain text email part

### DIFF
--- a/packages/html-to-plaintext/lib/html-to-plaintext.js
+++ b/packages/html-to-plaintext/lib/html-to-plaintext.js
@@ -61,12 +61,77 @@ const loadConverters = () => {
     });
 
     const emailSettings = mergeSettings({
+        preserveNewlines: false,
         selectors: [
             // equiv hideLinkHrefIfSameAsText: true
             {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
             // Don't include html .preheader in email
-            {selector: '.preheader', format: 'skip'}
-        ]
+            {selector: '.preheader', format: 'skip'},
+            {selector: 'p', options: {leadingLineBreaks: 2, trailingLineBreaks: 1}},
+            {selector: 'h1', format: 'customHeader'},
+            {selector: 'h2', format: 'customHeader'},
+            {selector: 'h3', format: 'customHeader'},
+            {selector: 'h4', format: 'customHeader'},
+            {selector: 'h5', options: {uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 1}},
+            {selector: 'h6', options: {uppercase: false, leadingLineBreaks: 2, trailingLineBreaks: 1}}
+        ],
+        formatters: {
+            customHeader: function (elem, walk, builder) {
+                function extractText(element) {
+                    if (element.type === 'text') {
+                        return element.data;
+                    }
+                    if (element.children) {
+                        return element.children.map(extractText).join('');
+                    }
+                    return '';
+                }
+
+                const text = extractText(elem).trim();
+                // Early return if header is empty
+                if (!text) {
+                    return;
+                }
+
+                const tagName = elem.name.toLowerCase();
+                const stars = '*'.repeat(text.length);
+                const dashes = '-'.repeat(text.length);
+
+                switch (tagName) {
+                case 'h1':
+                    builder.addLineBreak();
+                    builder.addLineBreak();
+                    builder.addInline(`${stars}`);
+                    builder.addLineBreak();
+                    builder.addInline(`${text}`);
+                    builder.addLineBreak();
+                    builder.addInline(`${stars}`);
+                    builder.addLineBreak();
+                    break;
+
+                case 'h2':
+                    builder.addLineBreak();
+                    builder.addLineBreak();
+                    builder.addInline(`${dashes}`);
+                    builder.addLineBreak();
+                    builder.addInline(`${text}`);
+                    builder.addLineBreak();
+                    builder.addInline(`${dashes}`);
+                    builder.addLineBreak();
+                    break;
+
+                case 'h3':
+                case 'h4':
+                    builder.addLineBreak();
+                    builder.addLineBreak();
+                    builder.addInline(`${text}`);
+                    builder.addLineBreak();
+                    builder.addInline(`${dashes}`);
+                    builder.addLineBreak();
+                    break;
+                }
+            }
+        }
     });
 
     const commentSettings = mergeSettings({

--- a/packages/html-to-plaintext/test/html-to-plaintext.test.js
+++ b/packages/html-to-plaintext/test/html-to-plaintext.test.js
@@ -88,6 +88,36 @@ describe('Html to Plaintext', function () {
         });
     });
 
+    describe('New lines and format headers', function () {
+        it('Strips excessive new lines and formats headers', function () {
+            const html = '<p>Some ordinary text</p>\n\n\n\n<p>Should not be way far apart from earlier text.</p>';
+            const expected = 'Some ordinary text\n\nShould not be way far apart from earlier text.';
+            const {email} = getEmailandExcert(html);
+            assert.equal(email, expected);
+        });
+
+        it('Check header formatting', function () {
+            const html = '<h1>Header One</h1>\n<p>What should I even write about?</p><p>And more</p><h2>With Header Two</h2><p>What about code?<h3>And Header Three</h3><p>Good bye</p>';
+            const expected = '\n**********\nHeader One\n**********\n\nWhat should I even write about?\n\nAnd more\n\n---------------\nWith Header Two\n---------------\n\nWhat about code?\n\nAnd Header Three\n----------------\n\nGood bye';
+            const {email} = getEmailandExcert(html);
+            assert.equal(email, expected);
+        });
+
+        it('Empty headers return nothing', function () {
+            const html = '<h1></h1>';
+            const expected = '';
+            const {email} = getEmailandExcert(html);
+            assert.equal(email, expected);
+        });
+
+        it('Non-text header contents don’t appear', function () {
+            const html = '<h1>Hello<!--Test-->world</h1>';
+            const expected = '\n**********\nHelloworld\n**********';
+            const {email} = getEmailandExcert(html);
+            assert.equal(email, expected);
+        });
+    });
+
     describe('commentSnippet converter', function () {
         function testConverter({input, expected}) {
             return () => {


### PR DESCRIPTION
see https://forum.ghost.org/t/unnecessary-and-excessive-newlines-in-plain-text-part-of-newsletters/60267/

- Previously relied on presence of \n in source HTML.
- Now sets reasonable new lines based on HTML elements.
- Formats headers for better readability.
- Tests added for all changes.

Headers now look like:
```
**********
Header One
**********

----------
Header Two
----------

Header Three and Four
---------------------

Header Five and Six
```