### PR TITLE
Added unit tests for url-utils

### DIFF
--- a/packages/url-utils/lib/utils/deduplicate-double-slashes.js
+++ b/packages/url-utils/lib/utils/deduplicate-double-slashes.js
@@ -1,5 +1,8 @@
 function deduplicateDoubleSlashes(url) {
-    return url.replace(/\/\//g, '/');
+    // Preserve protocol slashes (e.g., http://, https://) and only deduplicate
+    // slashes in the path portion. The pattern (^|[^:])\/\/+ matches double slashes
+    // that are either at the start of the string or not preceded by a colon.
+    return url.replace(/(^|[^:])\/\/+/g, '$1/');
 }
 
 module.exports = deduplicateDoubleSlashes;

--- a/packages/url-utils/test/unit/utils/absolute-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/absolute-to-transform-ready.test.js
@@ -35,6 +35,16 @@ describe('utils: absoluteToTransformReady()', function () {
         absoluteToTransformReady(url, root).should.eql('http://i%20don’t%20believe%20that%20our%20platform%20should%20take%20that%20down%20because%20i%20think%20there%20are%20things%20that%20different%20people%20get%20wrong');
     });
 
+    it('handles unparseable URLs that throw errors', function () {
+        // Test URLs that cause URL constructor to throw
+        let url = 'http://[invalid';
+        let root = 'https://example.com';
+        absoluteToTransformReady(url, root).should.eql('http://[invalid');
+
+        url = 'not a valid url at all!!!';
+        absoluteToTransformReady(url, root).should.eql('not a valid url at all!!!');
+    });
+
     describe('with matching root', function () {
         it('returns relative file', function () {
             let url = 'https://example.com/my/file.png';

--- a/packages/url-utils/test/unit/utils/deduplicate-double-slashes.test.js
+++ b/packages/url-utils/test/unit/utils/deduplicate-double-slashes.test.js
@@ -1,0 +1,30 @@
+require('../../utils');
+
+const deduplicateDoubleSlashes = require('../../../lib/utils/deduplicate-double-slashes');
+
+describe('utils: deduplicateDoubleSlashes()', function () {
+    it('should deduplicate double slashes in URL', function () {
+        deduplicateDoubleSlashes('http://example.com//path//to//file.png')
+            .should.eql('http://example.com/path/to/file.png');
+    });
+
+    it('should deduplicate multiple consecutive slashes', function () {
+        deduplicateDoubleSlashes('http://example.com///path////to///file.png')
+            .should.eql('http://example.com/path/to/file.png');
+    });
+
+    it('should handle path with no double slashes', function () {
+        deduplicateDoubleSlashes('http://example.com/path/to/file.png')
+            .should.eql('http://example.com/path/to/file.png');
+    });
+
+    it('should handle relative paths', function () {
+        deduplicateDoubleSlashes('//path//to//file.png')
+            .should.eql('/path/to/file.png');
+    });
+
+    it('should handle empty string', function () {
+        deduplicateDoubleSlashes('')
+            .should.eql('');
+    });
+});

--- a/packages/url-utils/test/unit/utils/html-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/html-to-transform-ready.test.js
@@ -1,0 +1,60 @@
+require('../../utils');
+
+const htmlToTransformReady = require('../../../lib/utils/html-to-transform-ready');
+
+describe('utils: htmlToTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    const itemPath = '/my-awesome-post';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('converts relative HTML to transform-ready', function () {
+        const html = '<a href="/about">Link</a><img src="/content/images/test.jpg">';
+        const result = htmlToTransformReady(html, siteUrl, itemPath, options);
+
+        result.should.containEql('<a href="__GHOST_URL__/about">Link</a>');
+        result.should.containEql('<img src="__GHOST_URL__/content/images/test.jpg">');
+    });
+
+    it('converts relative HTML with page-relative URLs', function () {
+        const html = '<a href="about">Link</a>';
+        const result = htmlToTransformReady(html, siteUrl, itemPath, options);
+
+        result.should.containEql('<a href="__GHOST_URL__/my-awesome-post/about">Link</a>');
+    });
+
+    it('handles options when itemPath is an object', function () {
+        const html = '<a href="/about">Link</a>';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images',
+            assetsOnly: true
+        };
+        const result = htmlToTransformReady(html, siteUrl, optionsAsItemPath);
+
+        result.should.containEql('<a href="/about">Link</a>');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const html = '<a href="/about">Link</a>';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = htmlToTransformReady(html, siteUrl, optionsAsItemPath, null);
+
+        result.should.containEql('<a href="__GHOST_URL__/about">Link</a>');
+    });
+
+    it('works with subdirectories', function () {
+        const url = 'http://my-ghost-blog.com/blog';
+        const html = '<a href="/blog/about">Link</a>';
+        const result = htmlToTransformReady(html, url, 'blog/my-post', options);
+
+        result.should.containEql('<a href="__GHOST_URL__/about">Link</a>');
+    });
+});
+

--- a/packages/url-utils/test/unit/utils/lexical-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/lexical-to-transform-ready.test.js
@@ -1,0 +1,188 @@
+require('../../utils');
+
+const lexicalToTransformReady = require('../../../lib/utils/lexical-to-transform-ready');
+
+describe('utils: lexicalToTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    const itemPath = '/my-awesome-post';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('converts relative lexical to transform-ready', function () {
+        const lexical = JSON.stringify({
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'Test',
+                                        type: 'text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'link',
+                                version: 1,
+                                rel: null,
+                                target: null,
+                                url: '/test'
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+
+        const result = lexicalToTransformReady(lexical, siteUrl, itemPath, options);
+        const parsed = JSON.parse(result);
+
+        parsed.root.children[0].children[0].url.should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles options when itemPath is an object', function () {
+        const lexical = JSON.stringify({
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'Test',
+                                        type: 'text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'link',
+                                version: 1,
+                                rel: null,
+                                target: null,
+                                url: '/test'
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = lexicalToTransformReady(lexical, siteUrl, optionsAsItemPath);
+        const parsed = JSON.parse(result);
+
+        parsed.root.children[0].children[0].url.should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const lexical = JSON.stringify({
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'Test',
+                                        type: 'text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'link',
+                                version: 1,
+                                rel: null,
+                                target: null,
+                                url: '/test'
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = lexicalToTransformReady(lexical, siteUrl, optionsAsItemPath, null);
+        const parsed = JSON.parse(result);
+
+        parsed.root.children[0].children[0].url.should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles empty lexical', function () {
+        const lexical = JSON.stringify({
+            root: {
+                children: [],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+
+        const result = lexicalToTransformReady(lexical, siteUrl, itemPath, options);
+        const parsed = JSON.parse(result);
+
+        parsed.root.children.should.be.an.Array();
+        parsed.root.children.length.should.equal(0);
+    });
+});
+

--- a/packages/url-utils/test/unit/utils/markdown-absolute-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-absolute-to-transform-ready.test.js
@@ -117,6 +117,57 @@ Testing <a href="__GHOST_URL__/link">Inline</a> with **markdown**
         result.should.equal('[![Test](__GHOST_URL__/content/images/2014/01/test.jpg)](__GHOST_URL__/content/images/2014/01/test.jpg)');
     });
 
+    it('handles default options when options is not provided', function () {
+        const markdown = 'This is a [link](http://my-ghost-blog.com/link)';
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles ignoreProtocol option', function () {
+        const markdown = 'This is a [link](https://my-ghost-blog.com/link)';
+        const testOptions = {
+            ignoreProtocol: true
+        };
+        const result = markdownAbsoluteToTransformReady(markdown, 'http://my-ghost-blog.com', testOptions);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles ignoreProtocol option set to false', function () {
+        const markdown = 'This is a [link](https://my-ghost-blog.com/link)';
+        const testOptions = {
+            ignoreProtocol: false
+        };
+        const result = markdownAbsoluteToTransformReady(markdown, 'http://my-ghost-blog.com', testOptions);
+
+        result.should.equal('This is a [link](https://my-ghost-blog.com/link)');
+    });
+
+    it('handles assetsOnly option', function () {
+        const markdown = '![](http://my-ghost-blog.com/content/images/image.png) [](http://my-ghost-blog.com/not-an-asset)';
+        const testOptions = {
+            assetsOnly: true
+        };
+        const result = markdownAbsoluteToTransformReady(markdown, siteUrl, testOptions);
+
+        result.should.equal('![](__GHOST_URL__/content/images/image.png) [](http://my-ghost-blog.com/not-an-asset)');
+    });
+
+    it('handles siteUrl with trailing slash', function () {
+        const markdown = 'This is a [link](http://my-ghost-blog.com/link)';
+        const result = markdownAbsoluteToTransformReady(markdown, 'http://my-ghost-blog.com/', options);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles siteUrl with https protocol', function () {
+        const markdown = 'This is a [link](https://my-ghost-blog.com/link)';
+        const result = markdownAbsoluteToTransformReady(markdown, 'https://my-ghost-blog.com', options);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
     describe('AST parsing is skipped', function () {
         let remarkSpy, sandbox;
 

--- a/packages/url-utils/test/unit/utils/markdown-relative-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-relative-to-transform-ready.test.js
@@ -137,6 +137,34 @@ Just testing
         `);
     });
 
+    it('handles default options when options is not provided', function () {
+        const markdown = 'This is a [link](/link)';
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles assetsOnly option with staticImageUrlPrefix', function () {
+        const markdown = '![](/content/images/image.png) [](/not-an-asset)';
+        const testOptions = {
+            assetsOnly: true,
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath, testOptions);
+
+        result.should.equal('![](__GHOST_URL__/content/images/image.png) [](/not-an-asset)');
+    });
+
+    it('handles assetsOnly option without staticImageUrlPrefix', function () {
+        const markdown = '![](/content/images/image.png) [](/not-an-asset)';
+        const testOptions = {
+            assetsOnly: true
+        };
+        const result = markdownRelativeToTransformReady(markdown, siteUrl, itemPath, testOptions);
+
+        result.should.equal('![](__GHOST_URL__/content/images/image.png) [](/not-an-asset)');
+    });
+
     describe('AST parsing is skipped', function () {
         let remarkSpy, sandbox;
 

--- a/packages/url-utils/test/unit/utils/markdown-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/markdown-to-transform-ready.test.js
@@ -1,0 +1,63 @@
+require('../../utils');
+
+const markdownToTransformReady = require('../../../lib/utils/markdown-to-transform-ready');
+
+describe('utils: markdownToTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    const itemPath = '/my-awesome-post';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('converts relative markdown to transform-ready', function () {
+        const markdown = 'This is a [link](/link) and this is an ![](/content/images/image.png)';
+        const result = markdownToTransformReady(markdown, siteUrl, itemPath, options);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link) and this is an ![](__GHOST_URL__/content/images/image.png)');
+    });
+
+    it('converts relative markdown with HTML', function () {
+        const markdown = 'Testing <a href="/link">Inline</a> with **markdown**';
+        const result = markdownToTransformReady(markdown, siteUrl, itemPath, options);
+
+        result.should.equal('Testing <a href="__GHOST_URL__/link">Inline</a> with **markdown**');
+    });
+
+    it('handles options when itemPath is an object', function () {
+        const markdown = 'This is a [link](/link)';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = markdownToTransformReady(markdown, siteUrl, optionsAsItemPath);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const markdown = 'This is a [link](/link)';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = markdownToTransformReady(markdown, siteUrl, optionsAsItemPath, null);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('works with subdirectories', function () {
+        const url = 'http://my-ghost-blog.com/blog';
+        const markdown = 'This is a [link](/blog/link)';
+        const result = markdownToTransformReady(markdown, url, 'blog/my-post', options);
+
+        result.should.equal('This is a [link](__GHOST_URL__/link)');
+    });
+
+    it('handles empty markdown', function () {
+        const result = markdownToTransformReady('', siteUrl, itemPath, options);
+        result.should.equal('');
+    });
+});
+

--- a/packages/url-utils/test/unit/utils/mobiledoc-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/mobiledoc-to-transform-ready.test.js
@@ -1,0 +1,107 @@
+require('../../utils');
+
+const mobiledocToTransformReady = require('../../../lib/utils/mobiledoc-to-transform-ready');
+
+describe('utils: mobiledocToTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    const itemPath = '/my-awesome-post';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('converts relative mobiledoc to transform-ready', function () {
+        const mobiledoc = {
+            version: '0.3.1',
+            atoms: [],
+            cards: [],
+            markups: [
+                ['a', ['href', '/test']]
+            ],
+            sections: [
+                [1, 'p', [
+                    [0, [0], 1, 'Test']
+                ]]
+            ]
+        };
+        const serializedMobiledoc = JSON.stringify(mobiledoc);
+
+        const result = mobiledocToTransformReady(serializedMobiledoc, siteUrl, itemPath, options);
+        const parsed = JSON.parse(result);
+
+        parsed.markups[0][1][1].should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles options when itemPath is an object', function () {
+        const mobiledoc = {
+            version: '0.3.1',
+            atoms: [],
+            cards: [],
+            markups: [
+                ['a', ['href', '/test']]
+            ],
+            sections: [
+                [1, 'p', [
+                    [0, [0], 1, 'Test']
+                ]]
+            ]
+        };
+        const serializedMobiledoc = JSON.stringify(mobiledoc);
+
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = mobiledocToTransformReady(serializedMobiledoc, siteUrl, optionsAsItemPath);
+        const parsed = JSON.parse(result);
+
+        parsed.markups[0][1][1].should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const mobiledoc = {
+            version: '0.3.1',
+            atoms: [],
+            cards: [],
+            markups: [
+                ['a', ['href', '/test']]
+            ],
+            sections: [
+                [1, 'p', [
+                    [0, [0], 1, 'Test']
+                ]]
+            ]
+        };
+        const serializedMobiledoc = JSON.stringify(mobiledoc);
+
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = mobiledocToTransformReady(serializedMobiledoc, siteUrl, optionsAsItemPath, null);
+        const parsed = JSON.parse(result);
+
+        parsed.markups[0][1][1].should.equal('__GHOST_URL__/test');
+    });
+
+    it('handles empty mobiledoc', function () {
+        const mobiledoc = {
+            version: '0.3.1',
+            atoms: [],
+            cards: [],
+            markups: [],
+            sections: []
+        };
+        const serializedMobiledoc = JSON.stringify(mobiledoc);
+
+        const result = mobiledocToTransformReady(serializedMobiledoc, siteUrl, itemPath, options);
+        const parsed = JSON.parse(result);
+
+        parsed.markups.should.be.an.Array();
+        parsed.markups.length.should.equal(0);
+        parsed.sections.should.be.an.Array();
+        parsed.sections.length.should.equal(0);
+    });
+});
+

--- a/packages/url-utils/test/unit/utils/plaintext-absolute-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/plaintext-absolute-to-transform-ready.test.js
@@ -20,4 +20,38 @@ describe('utils: plaintextAbsoluteToTransformReady', function () {
         plaintextAbsoluteToTransformReady(plaintext, siteUrl)
             .should.equal('Standard Link [__GHOST_URL__/standard-link], Different Protocol [__GHOST_URL__/second-link], Root-relative [http://my-ghost-blog.com/], and Different Domain [https://ghost.org]');
     });
+
+    it('handles options when itemPath is an object', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'Standard Link [http://my-ghost-blog.com/standard-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextAbsoluteToTransformReady(plaintext, siteUrl, optionsAsItemPath);
+
+        result.should.equal('Standard Link [__GHOST_URL__/standard-link]');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'Standard Link [http://my-ghost-blog.com/standard-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextAbsoluteToTransformReady(plaintext, siteUrl, optionsAsItemPath, null);
+
+        result.should.equal('Standard Link [__GHOST_URL__/standard-link]');
+    });
+
+    it('handles itemPath parameter', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'Standard Link [http://my-ghost-blog.com/standard-link]';
+        const itemPath = '/my-post';
+        const options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextAbsoluteToTransformReady(plaintext, siteUrl, itemPath, options);
+
+        result.should.equal('Standard Link [__GHOST_URL__/standard-link]');
+    });
 });

--- a/packages/url-utils/test/unit/utils/plaintext-relative-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/plaintext-relative-to-transform-ready.test.js
@@ -20,4 +20,38 @@ describe('utils: plaintextRelativeToTransformReady', function () {
         plaintextRelativeToTransformReady(plaintext, siteUrl)
             .should.equal('First Link [__GHOST_URL__/first-link] and Second Link [/second-link]');
     });
+
+    it('handles options when itemPath is an object', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'First Link [/first-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextRelativeToTransformReady(plaintext, siteUrl, optionsAsItemPath);
+
+        result.should.equal('First Link [__GHOST_URL__/first-link]');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'First Link [/first-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextRelativeToTransformReady(plaintext, siteUrl, optionsAsItemPath, null);
+
+        result.should.equal('First Link [__GHOST_URL__/first-link]');
+    });
+
+    it('handles itemPath parameter', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'First Link [/first-link]';
+        const itemPath = '/my-post';
+        const options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextRelativeToTransformReady(plaintext, siteUrl, itemPath, options);
+
+        result.should.equal('First Link [__GHOST_URL__/first-link]');
+    });
 });

--- a/packages/url-utils/test/unit/utils/plaintext-to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/plaintext-to-transform-ready.test.js
@@ -20,4 +20,26 @@ describe('utils: plaintextToTransformReady', function () {
         plaintextToTransformReady(plaintext, siteUrl)
             .should.equal('Relative Link [__GHOST_URL__/first-link], Absolute Link [__GHOST_URL__/second-link], and Root-relative [http://my-ghost-blog-com/other/]');
     });
+
+    it('handles options when itemPath is an object', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'Relative link [/first-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextToTransformReady(plaintext, siteUrl, optionsAsItemPath);
+
+        result.should.equal('Relative link [__GHOST_URL__/first-link]');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const siteUrl = 'http://my-ghost-blog.com';
+        const plaintext = 'Relative link [/first-link]';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = plaintextToTransformReady(plaintext, siteUrl, optionsAsItemPath, null);
+
+        result.should.equal('Relative link [__GHOST_URL__/first-link]');
+    });
 });

--- a/packages/url-utils/test/unit/utils/relative-to-absolute.test.js
+++ b/packages/url-utils/test/unit/utils/relative-to-absolute.test.js
@@ -21,6 +21,11 @@ describe('utils: relativeToAbsolute()', function () {
 
         root = 'https://example.com/subdir/';
         relativeToAbsolute(url, root).should.eql('//mysite.com/my/file.png', 'with /subdir/ root');
+
+        // Test protocol-relative URL that would parse successfully
+        url = '//example.com/path';
+        root = 'https://example.com';
+        relativeToAbsolute(url, root).should.eql('//example.com/path', 'protocol-relative with matching domain');
     });
 
     it('ignores non-root-relative URLs', function () {

--- a/packages/url-utils/test/unit/utils/replace-permalink.test.js
+++ b/packages/url-utils/test/unit/utils/replace-permalink.test.js
@@ -112,4 +112,25 @@ describe('utils: replacePermalink()', function () {
 
         replacePermalink('/:year/:month/:day/:slug/', testData, timezone).should.equal(postLink);
     });
+
+    it('permalink is /:primary_author/:slug/ and there is NO primary_author', function () {
+        const testData = {
+            slug: 'short-and-sweet'
+        };
+        const timezone = 'Europe/Berlin';
+        const postLink = '/all/short-and-sweet/';
+
+        replacePermalink('/:primary_author/:slug/', testData, timezone).should.equal(postLink);
+    });
+
+    it('permalink is /:primary_author/:slug/ and primary_author is null', function () {
+        const testData = {
+            slug: 'short-and-sweet',
+            primary_author: null
+        };
+        const timezone = 'Europe/Berlin';
+        const postLink = '/all/short-and-sweet/';
+
+        replacePermalink('/:primary_author/:slug/', testData, timezone).should.equal(postLink);
+    });
 });

--- a/packages/url-utils/test/unit/utils/strip-subdirectory-from-path.test.js
+++ b/packages/url-utils/test/unit/utils/strip-subdirectory-from-path.test.js
@@ -34,4 +34,24 @@ describe('utils: stripSubdomainFromPath()', function () {
         stripSubdirectoryFromPath(path, 'https://example.com/my/subdir/')
             .should.eql('/my/path.png', 'without root trailing-slash');
     });
+
+    it('returns path as-is when path does not start with subdirectory', function () {
+        let path = '/other/path.png';
+
+        stripSubdirectoryFromPath(path, 'https://example.com/subdir')
+            .should.eql('/other/path.png', 'path does not match subdirectory');
+
+        stripSubdirectoryFromPath(path, 'https://example.com/subdir/')
+            .should.eql('/other/path.png', 'path does not match subdirectory');
+    });
+
+    it('handles invalid rootUrl gracefully', function () {
+        let path = '/my/path.png';
+
+        stripSubdirectoryFromPath(path, 'not a valid url')
+            .should.eql('/my/path.png', 'invalid rootUrl returns path as-is');
+
+        stripSubdirectoryFromPath(path, '')
+            .should.eql('/my/path.png', 'empty rootUrl returns path as-is');
+    });
 });

--- a/packages/url-utils/test/unit/utils/to-transform-ready.test.js
+++ b/packages/url-utils/test/unit/utils/to-transform-ready.test.js
@@ -1,0 +1,72 @@
+require('../../utils');
+
+const toTransformReady = require('../../../lib/utils/to-transform-ready');
+
+describe('utils: toTransformReady()', function () {
+    const siteUrl = 'http://my-ghost-blog.com';
+    const itemPath = '/my-awesome-post';
+    let options;
+
+    beforeEach(function () {
+        options = {
+            staticImageUrlPrefix: 'content/images'
+        };
+    });
+
+    it('converts relative URL to transform-ready', function () {
+        const url = '/my/file.png';
+        const result = toTransformReady(url, siteUrl, itemPath, options);
+
+        result.should.equal('__GHOST_URL__/my/file.png');
+    });
+
+    it('converts page-relative URL to transform-ready', function () {
+        const url = 'my/file.png';
+        const result = toTransformReady(url, siteUrl, itemPath, options);
+
+        result.should.equal('__GHOST_URL__/my-awesome-post/my/file.png');
+    });
+
+    it('handles options when itemPath is an object', function () {
+        const url = '/my/file.png';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = toTransformReady(url, siteUrl, optionsAsItemPath);
+
+        result.should.equal('__GHOST_URL__/my/file.png');
+    });
+
+    it('handles options when itemPath is an object and options is null', function () {
+        const url = '/my/file.png';
+        const optionsAsItemPath = {
+            staticImageUrlPrefix: 'content/images'
+        };
+        const result = toTransformReady(url, siteUrl, optionsAsItemPath, null);
+
+        result.should.equal('__GHOST_URL__/my/file.png');
+    });
+
+    it('works with subdirectories', function () {
+        const url = 'http://my-ghost-blog.com/blog/my/file.png';
+        const rootUrl = 'http://my-ghost-blog.com/blog';
+        const result = toTransformReady(url, rootUrl, itemPath, options);
+
+        result.should.equal('__GHOST_URL__/my/file.png');
+    });
+
+    it('handles absolute URLs', function () {
+        const url = 'http://my-ghost-blog.com/my/file.png';
+        const result = toTransformReady(url, siteUrl, itemPath, options);
+
+        result.should.equal('__GHOST_URL__/my/file.png');
+    });
+
+    it('ignores external URLs', function () {
+        const url = 'http://external.com/my/file.png';
+        const result = toTransformReady(url, siteUrl, itemPath, options);
+
+        result.should.equal('http://external.com/my/file.png');
+    });
+});
+


### PR DESCRIPTION
no issue

This PR is the first step towards migrating urlUtils to TS. This increases the test coverage of the package. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves protocol slashes in URL deduplication and expands unit test coverage across transform-ready helpers and edge cases.
> 
> - **Fix**:
>   - Update `lib/utils/deduplicate-double-slashes.js` to preserve protocol (`http://`, `https://`) while collapsing multiple slashes in paths.
> - **Tests**:
>   - Add new suites for `html-to-transform-ready`, `lexical-to-transform-ready`, `markdown-to-transform-ready`, `mobiledoc-to-transform-ready`, `to-transform-ready`, and `deduplicate-double-slashes` covering relative/page-relative URLs, subdirectories, assetsOnly/staticImageUrlPrefix, defaults, and empty inputs.
>   - Extend `absolute-to-transform-ready` with unparseable URL handling.
>   - Extend `markdown-absolute-to-transform-ready` and `markdown-relative-to-transform-ready` with default options, protocol handling, assets-only behavior, and trailing-slash/https cases; verify AST parsing is skipped when possible.
>   - Extend `plaintext-absolute/relative/to-transform-ready` with options-as-itemPath and itemPath parameter handling.
>   - Extend `relative-to-absolute` with protocol-relative matching-domain case.
>   - Extend `replace-permalink` to handle missing/null `primary_author`.
>   - Extend `strip-subdirectory-from-path` to handle non-matching paths and invalid `rootUrl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a82935656f3d8d026012bce1ad9ee8542b8db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->