### PR TITLE
Added can_comment and comment_ban fields to members schema

### DIFF
--- a/packages/admin-api-schema/lib/schemas/comment_bans-add.json
+++ b/packages/admin-api-schema/lib/schemas/comment_bans-add.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "comment_bans.add",
+  "title": "comment_bans.add",
+  "description": "Schema for comment_bans.add",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "comment_bans": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "allOf": [{ "$ref": "comment_bans#/definitions/comment_ban" }]
+      }
+    }
+  },
+  "required": ["comment_bans"]
+}

--- a/packages/admin-api-schema/lib/schemas/comment_bans.json
+++ b/packages/admin-api-schema/lib/schemas/comment_bans.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "comment_bans",
+  "title": "comment_bans",
+  "description": "Base comment_bans definitions",
+  "definitions": {
+    "comment_ban": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2000
+        },
+        "expires_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      },
+      "required": ["reason"]
+    }
+  }
+}

--- a/packages/admin-api-schema/lib/schemas/index.js
+++ b/packages/admin-api-schema/lib/schemas/index.js
@@ -1,4 +1,5 @@
 module.exports = [
+    'comment_bans-add',
     'images-upload',
     'media-upload',
     'labels-add',

--- a/packages/admin-api-schema/lib/schemas/members-edit.json
+++ b/packages/admin-api-schema/lib/schemas/members-edit.json
@@ -50,6 +50,23 @@
           },
           "labels": {
             "$ref": "members#/definitions/member-labels"
+          },
+          "can_comment": {
+            "type": "boolean"
+          },
+          "comment_ban": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "reason": { "type": "string", "minLength": 1, "maxLength": 2000 },
+                  "expires_at": { "type": ["string", "null"], "format": "date-time" }
+                },
+                "required": ["reason"]
+              },
+              { "type": "null" }
+            ]
           }
         }
       }

--- a/packages/admin-api-schema/lib/schemas/members.json
+++ b/packages/admin-api-schema/lib/schemas/members.json
@@ -47,6 +47,23 @@
         },
         "newsletters": {
           "$ref": "#/definitions/member-newsletters"
+        },
+        "can_comment": {
+          "type": "boolean"
+        },
+        "comment_ban": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "reason": { "type": "string", "minLength": 1, "maxLength": 2000 },
+                "expires_at": { "type": ["string", "null"], "format": "date-time" }
+              },
+              "required": ["reason"]
+            },
+            { "type": "null" }
+          ]
         }
       }
     },

--- a/packages/admin-api-schema/package.json
+++ b/packages/admin-api-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-api-schema",
-  "version": "4.5.13",
+  "version": "4.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/SDK.git",


### PR DESCRIPTION
## Description

Adds comment moderation fields to the members schema and a dedicated schema for the comment ban endpoint, enabling the Admin API to validate comment ban requests. This supports the member comment ban feature.

### Changes
- Added `comment_bans.json` base schema with `comment_ban` definition:
  - `reason` (string, required, minLength: 1, maxLength: 2000): explanation for the ban
  - `expires_at` (string|null, optional, format: date-time): ISO 8601 timestamp for temporary bans
- Added `comment_bans-add.json` schema for the `/members/:id/comment-ban` endpoint
- Added `can_comment` (boolean) to member properties
- Added `comment_ban` property to member schema (references shared definition, allows null)
- Bumped version to 4.6.0 (minor - new backwards-compatible feature)

ref https://linear.app/ghost/issue/FEA-487
ref https://github.com/TryGhost/Ghost/pull/25791

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces comment moderation support in the Admin API schema.
> 
> - Adds `comment_bans.json` base schema with `comment_ban` definition (`reason`, optional `expires_at`)
> - Adds `comment_bans-add.json` for `comment_bans.add` endpoint and registers it in `index.js`
> - Extends member schemas (`members.json`, `members-edit.json`) with `can_comment` (boolean) and `comment_ban` (object or null)
> - Bumps `@tryghost/admin-api-schema` to `4.6.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1523b68a0828b0d8cec736308523d621c19382cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->