### PR TITLE
Added support for `gift_id` column in members CSV

### DIFF
--- a/packages/members-csv/lib/unparse.js
+++ b/packages/members-csv/lib/unparse.js
@@ -11,7 +11,8 @@ const DEFAULT_COLUMNS = [
     'created_at',
     'deleted_at',
     'labels',
-    'tiers'
+    'tiers',
+    'gift_id'
 ];
 
 const unparse = (rows, columns = DEFAULT_COLUMNS.slice()) => {
@@ -56,6 +57,7 @@ const unparse = (rows, columns = DEFAULT_COLUMNS.slice()) => {
             labels: labels,
             tiers: tiers,
             import_tier: row.import_tier || null,
+            gift_id: row.gift_id || null,
             error: row.error || null
         };
     });

--- a/packages/members-csv/package.json
+++ b/packages/members-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/members-csv",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/SDK.git",

--- a/packages/members-csv/test/unparse.test.js
+++ b/packages/members-csv/test/unparse.test.js
@@ -13,7 +13,7 @@ describe('unparse', function () {
 
         assert.ok(result);
 
-        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers\r\n,email@example.com,Sam Memberino,Early supporter,,,,,,,`;
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id\r\n,email@example.com,Sam Memberino,Early supporter,,,,,,,,`;
         assert.equal(result, expected);
     });
 
@@ -114,7 +114,7 @@ third-member-email@email.com,"banana, avocado"`;
         const result = unparse(json);
         assert.ok(result);
 
-        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers\r\n,email@example.com,"'=1+2",Early supporter,,,,,,,`;
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id\r\n,email@example.com,"'=1+2",Early supporter,,,,,,,,`;
         assert.equal(result, expected);
     });
 
@@ -128,7 +128,51 @@ third-member-email@email.com,"banana, avocado"`;
         const result = unparse(json);
         assert.ok(result);
 
-        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers\r\n,email@example.com,"'=1+2'"" ",Early supporter,,,,,,,`;
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id\r\n,email@example.com,"'=1+2'"" ",Early supporter,,,,,,,,`;
+        assert.equal(result, expected);
+    });
+
+    it('includes gift_id in default output when set on a row', function () {
+        const json = [{
+            email: 'gift@example.com',
+            gift_id: 'gift123'
+        }];
+
+        const result = unparse(json);
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id\r\n,gift@example.com,,,,,,,,,,gift123`;
+        assert.equal(result, expected);
+    });
+
+    it('includes gift_id column in default output even when no row has a value', function () {
+        const json = [{
+            email: 'no-gift@example.com'
+        }];
+
+        const result = unparse(json);
+        const header = result.split('\r\n')[0];
+        assert.ok(header.split(',').includes('gift_id'));
+    });
+
+    it('omits gift_id when an explicit columns array does not include it', function () {
+        const json = [{
+            email: 'gift@example.com',
+            gift_id: 'gift123'
+        }];
+        const columns = ['email'];
+
+        const result = unparse(json, columns);
+        const expected = `email\r\ngift@example.com`;
+        assert.equal(result, expected);
+    });
+
+    it('serializes gift_id as empty when row has no gift_id', function () {
+        const json = [{
+            email: 'no-gift@example.com'
+        }];
+        const columns = ['email', 'gift_id'];
+
+        const result = unparse(json, columns);
+        const expected = `email,gift_id\r\nno-gift@example.com,`;
         assert.equal(result, expected);
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3483

Added support for `gift_id` column in members CSV which can be used to link a member to a gift on import