### PR TITLE
Use .blue() instead of .b() in textColorForBackgroundColor

### DIFF
--- a/packages/color-utils/cjs/color-utils.js
+++ b/packages/color-utils/cjs/color-utils.js
@@ -37,7 +37,7 @@ function textColorForBackgroundColor(background) {
     // shared with Portal https://github.com/TryGhost/Portal/blob/317876f20d22431df15e655ea6cc197fe636615e/src/utils/contrast-color.js#L26-L29
     const yiq = (backgroundColor.red() * 0.299 +
         backgroundColor.green() * 0.587 +
-        backgroundColor.b() * 0.114);
+        backgroundColor.blue() * 0.114);
     return (yiq >= 186) ? black : white;
 }
 

--- a/packages/color-utils/es/color-utils.js
+++ b/packages/color-utils/es/color-utils.js
@@ -2160,7 +2160,7 @@ function textColorForBackgroundColor(background) {
     // shared with Portal https://github.com/TryGhost/Portal/blob/317876f20d22431df15e655ea6cc197fe636615e/src/utils/contrast-color.js#L26-L29
     const yiq = (backgroundColor.red() * 0.299 +
         backgroundColor.green() * 0.587 +
-        backgroundColor.b() * 0.114);
+        backgroundColor.blue() * 0.114);
     return (yiq >= 186) ? black : white;
 }
 

--- a/packages/color-utils/src/color-utils.ts
+++ b/packages/color-utils/src/color-utils.ts
@@ -50,7 +50,7 @@ export function textColorForBackgroundColor(background: string | Color): Color {
     const yiq = (
         backgroundColor.red() * 0.299 +
         backgroundColor.green() * 0.587 +
-        backgroundColor.b() * 0.114
+        backgroundColor.blue() * 0.114
     );
 
     return (yiq >= 186) ? black : white;


### PR DESCRIPTION
.b() returns the HSB brightness component, not the blue RGB channel. This caused incorrect YIQ calculation for most colors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix in `textColorForBackgroundColor` that changes text color selection results for some backgrounds; low risk but may affect UI contrast outcomes.
> 
> **Overview**
> Fixes `textColorForBackgroundColor`’s YIQ computation to use the RGB blue channel via `blue()` instead of `b()` (which refers to a different color component), correcting text color selection for many backgrounds.
> 
> Rebuilds the generated `cjs`/`es` outputs to reflect this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301ad96b6425d512e061a585e80c259b12018002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->