### PR TITLE
Added .preheader-spacing plaintext exclusion

### DIFF
--- a/packages/html-to-plaintext/lib/html-to-plaintext.js
+++ b/packages/html-to-plaintext/lib/html-to-plaintext.js
@@ -65,7 +65,8 @@ const loadConverters = () => {
             // equiv hideLinkHrefIfSameAsText: true
             {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
             // Don't include html .preheader in email
-            {selector: '.preheader', format: 'skip'}
+            {selector: '.preheader', format: 'skip'},
+            {selector: '.preheader-spacing', format: 'skip'}
         ]
     });
 


### PR DESCRIPTION
ref [ONC-1682](https://linear.app/ghost/issue/ONC-1682/plain-text-newsletter-encoding-artifacts-potential-deliverability)

The spacing inserts a bunch of dodgy characters into the plaintext version of emails.
