### PR TITLE
Added publicSiteAccess flag limit

### DIFF
--- a/packages/limit-service/lib/config.js
+++ b/packages/limit-service/lib/config.js
@@ -58,5 +58,6 @@ module.exports = {
     },
     limitStripeConnect: {},
     limitAnalytics: {},
-    limitSocialWeb: {}
+    limitSocialWeb: {},
+    publicSiteAccess: {}
 };

--- a/packages/limit-service/test/LimitService.test.js
+++ b/packages/limit-service/test/LimitService.test.js
@@ -152,6 +152,19 @@ describe('Limit Service', function () {
             limitService.isLimited('limitSocialWeb').should.be.true();
         });
 
+        it('can load publicSiteAccess flag limit', function () {
+            const limitService = new LimitService();
+
+            let limits = {publicSiteAccess: {disabled: true}};
+
+            limitService.loadLimits({limits, errors});
+
+            limitService.limits.should.be.an.Object().with.properties(['publicSiteAccess']);
+            limitService.limits.publicSiteAccess.should.be.an.instanceOf(FlagLimit);
+            limitService.isLimited('publicSiteAccess').should.be.true();
+            limitService.isDisabled('publicSiteAccess').should.be.true();
+        });
+
         it('can load camel cased limits', function () {
             const limitService = new LimitService();
 


### PR DESCRIPTION
## Summary

- Adds `publicSiteAccess` to the limit-service config allowlist so Ghost(Pro) can use it as a FlagLimit (`{disabled: true}`) to lock new trial sites to private-only visibility while the customer is on the free trial.
- Pure allowlist addition — no behavioural change for any existing limit.

## Why now

Ghost backend ships weekly; admin code is on CD. To unblock the Ghost Core enforcement PR (settings init enforcement, BREAD blocks, `is_read_only` marking on `is_private`/`password`) we need a published `@tryghost/limit-service` that recognises the new name.

`LimitService.loadLimits()` silently no-ops on names that are not in `lib/config.js` (the `if (config[name])` gate), so older Ghost versions reading a Daisy blog config containing `publicSiteAccess` will continue to function — this can land safely ahead of any data changes in Daisy.

## Test plan

- [x] `NODE_ENV=testing mocha './test/**/*.test.js'` — 67 passing, including new `can load publicSiteAccess flag limit` case that asserts FlagLimit registration, `isLimited`, and `isDisabled`.
- [x] `eslint . --ext .js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)