### PR TITLE
Moved release-utils from Utils (archived) into SDK

### DIFF
--- a/packages/release-utils/.c8rc.json
+++ b/packages/release-utils/.c8rc.json
@@ -1,4 +1,0 @@
-{
-  "all": true,
-  "checkCoverage": false
-}

--- a/packages/release-utils/.c8rc.json
+++ b/packages/release-utils/.c8rc.json
@@ -1,0 +1,4 @@
+{
+  "all": true,
+  "checkCoverage": false
+}

--- a/packages/release-utils/.eslintrc.js
+++ b/packages/release-utils/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/packages/release-utils/LICENSE
+++ b/packages/release-utils/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2022 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/release-utils/README.md
+++ b/packages/release-utils/README.md
@@ -1,0 +1,127 @@
+# Release Utils
+
+## Install
+
+`npm install @tryghost/release-utils --save`
+
+or
+
+`yarn add @tryghost/release-utils`
+
+
+## Usage
+
+Create Gist:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+releaseUtils
+    .gist
+    .create({
+        userAgent: String,
+        gistName: String,
+        gistDescription: String,
+        changelogPath: String [Path on Disk]
+        github: {
+            username: String
+            token: String
+        },
+        isPublic: Boolean [optional, Default: true]
+    })
+```
+
+Create Changelog:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+const changelog = new releaseUtils.Changelog({
+    changelogPath: String [Path on Disk],
+    folder: String [Path on Disk]
+});
+
+changelog
+    .write({
+        githubRepoPath: String,
+        lastVersion: String
+    })
+    .write({
+        githubRepoPath: String
+        lastVersion: String
+        append: Boolean [optional, Default: false],
+        folder: String [optional, Path on Disk]
+    })
+    .sort()
+    .clean()
+```
+
+Create & Upload Release:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+releaseUtils
+    .releases
+    .create({
+        tagName: String,
+        releaseName: String,
+        userAgent: String,
+        uri: String,
+        github: {
+            username: String,
+            token: String,
+        },
+        changelogPath: String [Path on Disk] OR Array[{
+            changelogPath: String [Path on Disk],
+            content: Array [optional]
+        }],
+        gistUrl: String [optional],
+        preRelease: Boolean [optional, Default: false],
+        draft: Boolean [optional, Default: true],
+        filterEmojiCommits: Boolean [optional, Default: true],
+        content: Array [optional]
+    });
+
+releaseUtils
+    .releases
+    .uploadZip({
+        github: {
+            username: String,
+            token: String
+        },
+        zipPath: String [Path on Disk],
+        uri: String,
+        userAgent: String
+    })
+```
+
+
+## Develop
+
+This is a mono repository, managed with [lerna](https://lernajs.io/).
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+## Run
+
+- `yarn dev`
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+
+
+
+
+# Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/release-utils/lib/Changelog.js
+++ b/packages/release-utils/lib/Changelog.js
@@ -1,0 +1,53 @@
+const execa = require('execa');
+const _ = require('lodash');
+
+const localUtils = require('./utils');
+
+class Changelog {
+    constructor(options = {}) {
+        localUtils.checkMissingOptions(options,
+            'folder',
+            'changelogPath'
+        );
+
+        this.changelogPath = options.changelogPath;
+        this.folder = options.folder;
+    }
+
+    write(options = {}) {
+        localUtils.checkMissingOptions(options,
+            'githubRepoPath',
+            'lastVersion'
+        );
+
+        let sign = '>';
+
+        if (options.append) {
+            sign = '>>';
+        }
+
+        const commands = [
+            `git log --no-merges --pretty=tformat:'%at * [%h](${options.githubRepoPath}/commit/%h) %s - %an' ${options.lastVersion}.. | sed 's/(#[0-9]{1,})//g' ${sign} ${this.changelogPath}`
+        ];
+
+        _.each(commands, (command) => {
+            execa.sync(command, {cwd: options.folder || this.folder, shell: true});
+        });
+
+        return this;
+    }
+
+    sort() {
+        execa.sync(`sort -r ${this.changelogPath} -o ${this.changelogPath}`, {cwd: this.folder, shell: true});
+
+        return this;
+    }
+
+    clean() {
+        execa.sync(`sed -i.bk -E 's/^[0-9]{10} //g' ${this.changelogPath}`, {cwd: this.folder, shell: true});
+
+        return this;
+    }
+}
+
+module.exports = Changelog;

--- a/packages/release-utils/lib/gist.js
+++ b/packages/release-utils/lib/gist.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const requestPromise = require('request-promise');
+
+const localUtils = require('./utils');
+
+module.exports.create = (options = {}) => {
+    let isPublic = true;
+
+    localUtils.checkMissingOptions(options,
+        'changelogPath',
+        'gistName',
+        'gistDescription',
+        'github',
+        'github.token',
+        'userAgent'
+    );
+
+    if (Object.prototype.hasOwnProperty.call(options, 'isPublic')) {
+        isPublic = options.isPublic;
+    }
+
+    const content = fs.readFileSync(options.changelogPath);
+    const files = {};
+
+    files[options.gistName] = {
+        content: content.toString('utf8')
+    };
+
+    const auth = 'token ' + options.github.token;
+
+    const reqOptions = {
+        uri: 'https://api.github.com/gists',
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth
+        },
+        method: 'POST',
+        body: {
+            description: options.gistDescription,
+            public: isPublic,
+            files: files
+        },
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return {
+                gistUrl: response.body.html_url
+            };
+        });
+};

--- a/packages/release-utils/lib/gist.js
+++ b/packages/release-utils/lib/gist.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const requestPromise = require('request-promise');
+const axios = require('axios');
 
 const localUtils = require('./utils');
 
@@ -28,26 +28,21 @@ module.exports.create = (options = {}) => {
 
     const auth = 'token ' + options.github.token;
 
-    const reqOptions = {
-        uri: 'https://api.github.com/gists',
+    return axios({
+        url: 'https://api.github.com/gists',
+        method: 'POST',
         headers: {
             'User-Agent': options.userAgent,
             Authorization: auth
         },
-        method: 'POST',
-        body: {
+        data: {
             description: options.gistDescription,
             public: isPublic,
             files: files
-        },
-        json: true,
-        resolveWithFullResponse: true
-    };
-
-    return requestPromise(reqOptions)
-        .then((response) => {
-            return {
-                gistUrl: response.body.html_url
-            };
-        });
+        }
+    }).then((response) => {
+        return {
+            gistUrl: response.data.html_url
+        };
+    });
 };

--- a/packages/release-utils/lib/index.js
+++ b/packages/release-utils/lib/index.js
@@ -1,0 +1,17 @@
+module.exports = {
+    get Changelog() {
+        return require('./Changelog');
+    },
+
+    get releases() {
+        return require('./releases');
+    },
+
+    get gist() {
+        return require('./gist');
+    },
+
+    get utils() {
+        return require('./utils');
+    }
+};

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const os = require('os');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const requestPromise = require('request-promise');
+const request = require('request');
+
+const localUtils = require('./utils');
+
+module.exports.create = (options = {}) => {
+    let draft = true;
+    let prerelease = false;
+
+    localUtils.checkMissingOptions(options,
+        'changelogPath',
+        'github',
+        'github.token',
+        'userAgent',
+        'uri',
+        'tagName',
+        'releaseName'
+    );
+
+    if (Object.prototype.hasOwnProperty.call(options, 'draft')) {
+        draft = options.draft;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(options, 'prerelease')) {
+        prerelease = options.prerelease;
+    }
+
+    let body = [];
+    // CASE: changelogPath can be array of paths with content
+    if (_.isArray(options.changelogPath)) {
+        options.changelogPath.forEach((opts) => {
+            body = body.concat(localUtils.getFinalChangelog(opts));
+        });
+    } else {
+        // CASE: changelogPath can be a single path(For backward compatibility)
+        body = body.concat(localUtils.getFinalChangelog(options));
+    }
+
+    // CASE: clean before upload
+    body = body.filter((item) => {
+        return item !== undefined;
+    });
+
+    if (options.gistUrl) {
+        body.push('');
+        body.push('You can see the [full change log](' + options.gistUrl + ') for the details of every change included in this release.');
+    }
+
+    if (options.extraText) {
+        body.push('');
+        body.push(options.extraText);
+    }
+
+    const auth = 'token ' + options.github.token;
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth
+        },
+        method: 'POST',
+        body: {
+            tag_name: options.tagName,
+            target_commitish: options.targetRef || 'main',
+            name: options.releaseName,
+            body: body.join(os.EOL),
+            draft: draft,
+            prerelease: prerelease
+        },
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return {
+                id: response.body.id,
+                releaseUrl: response.body.html_url,
+                uploadUrl: response.body.upload_url
+            };
+        });
+};
+
+module.exports.uploadZip = (options = {}) => {
+    localUtils.checkMissingOptions(options,
+        'zipPath',
+        'github',
+        'github.token',
+        'userAgent',
+        'uri'
+    );
+
+    const auth = 'token ' + options.github.token;
+    const stats = fs.statSync(options.zipPath);
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth,
+            'Content-Type': 'application/zip',
+            'Content-Length': stats.size
+        },
+        method: 'POST',
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return new Promise((resolve, reject) => {
+        fs.createReadStream(options.zipPath)
+            .on('error', reject)
+            .pipe(request.post(reqOptions, (err, res) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve({
+                    downloadUrl: res.body.browser_download_url
+                });
+            }));
+    });
+};
+
+module.exports.get = (options = {}) => {
+    localUtils.checkMissingOptions(options,
+        'userAgent',
+        'uri'
+    );
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent
+        },
+        method: 'GET',
+        json: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return response;
+        });
+};

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -1,9 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const _ = require('lodash');
-const Promise = require('bluebird');
-const requestPromise = require('request-promise');
-const request = require('request');
+const axios = require('axios');
 
 const localUtils = require('./utils');
 
@@ -57,33 +55,28 @@ module.exports.create = (options = {}) => {
 
     const auth = 'token ' + options.github.token;
 
-    const reqOptions = {
-        uri: options.uri,
+    return axios({
+        url: options.uri,
+        method: 'POST',
         headers: {
             'User-Agent': options.userAgent,
             Authorization: auth
         },
-        method: 'POST',
-        body: {
+        data: {
             tag_name: options.tagName,
             target_commitish: options.targetRef || 'main',
             name: options.releaseName,
             body: body.join(os.EOL),
             draft: draft,
             prerelease: prerelease
-        },
-        json: true,
-        resolveWithFullResponse: true
-    };
-
-    return requestPromise(reqOptions)
-        .then((response) => {
-            return {
-                id: response.body.id,
-                releaseUrl: response.body.html_url,
-                uploadUrl: response.body.upload_url
-            };
-        });
+        }
+    }).then((response) => {
+        return {
+            id: response.data.id,
+            releaseUrl: response.data.html_url,
+            uploadUrl: response.data.upload_url
+        };
+    });
 };
 
 module.exports.uploadZip = (options = {}) => {
@@ -98,31 +91,22 @@ module.exports.uploadZip = (options = {}) => {
     const auth = 'token ' + options.github.token;
     const stats = fs.statSync(options.zipPath);
 
-    const reqOptions = {
-        uri: options.uri,
+    return axios({
+        url: options.uri,
+        method: 'POST',
         headers: {
             'User-Agent': options.userAgent,
             Authorization: auth,
             'Content-Type': 'application/zip',
             'Content-Length': stats.size
         },
-        method: 'POST',
-        json: true,
-        resolveWithFullResponse: true
-    };
-
-    return new Promise((resolve, reject) => {
-        fs.createReadStream(options.zipPath)
-            .on('error', reject)
-            .pipe(request.post(reqOptions, (err, res) => {
-                if (err) {
-                    return reject(err);
-                }
-
-                resolve({
-                    downloadUrl: res.body.browser_download_url
-                });
-            }));
+        data: fs.createReadStream(options.zipPath),
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity
+    }).then((response) => {
+        return {
+            downloadUrl: response.data.browser_download_url
+        };
     });
 };
 
@@ -132,17 +116,13 @@ module.exports.get = (options = {}) => {
         'uri'
     );
 
-    const reqOptions = {
-        uri: options.uri,
+    return axios({
+        url: options.uri,
+        method: 'GET',
         headers: {
             'User-Agent': options.userAgent
-        },
-        method: 'GET',
-        json: true
-    };
-
-    return requestPromise(reqOptions)
-        .then((response) => {
-            return response;
-        });
+        }
+    }).then((response) => {
+        return response.data;
+    });
 };

--- a/packages/release-utils/lib/utils.js
+++ b/packages/release-utils/lib/utils.js
@@ -1,0 +1,93 @@
+const emojiRegex = require('emoji-regex');
+const fs = require('fs');
+const os = require('os');
+const _ = require('lodash');
+const {IncorrectUsageError} = require('@tryghost/errors');
+
+const timestamp = /^[0-9]{10} /;
+const separator = /^\* /;
+const hash = /^\[[0-9a-f]{0,10}\]/;
+const url = /^\(https?:\/\/[^)]+\) /;
+
+const getCommitMessageFromLine = line => line
+    .replace(timestamp, '')
+    .replace(separator, '')
+    .replace(hash, '')
+    .replace(url, '');
+
+const emojiOrder = ['💡', '🐛', '🎨', '💄', '✨', '🔒'];
+
+module.exports.filterEmojiCommits = (content) => {
+    if (!_.isArray(content)) {
+        throw new IncorrectUsageError({
+            message: 'Expected array of strings.'
+        });
+    }
+
+    return content.reduce((emojiLines, currentLine) => {
+        const commitMessage = getCommitMessageFromLine(currentLine);
+        const match = emojiRegex().exec(commitMessage);
+
+        if (match && match.index === 0) {
+            return emojiLines.concat(`* ${commitMessage}`);
+        }
+
+        return emojiLines;
+    }, []);
+};
+
+module.exports.sortByEmoji = (content) => {
+    if (!_.isArray(content)) {
+        throw new IncorrectUsageError({
+            message: 'Expected array of strings.'
+        });
+    }
+
+    content.sort((a, b) => {
+        let firstEmoji = [...a][2];
+        let secondEmoji = [...b][2];
+
+        let firstEmojiIndex = _.indexOf(emojiOrder, firstEmoji);
+        let secondEmojiIndex = _.indexOf(emojiOrder, secondEmoji);
+
+        return secondEmojiIndex - firstEmojiIndex;
+    });
+};
+
+module.exports.checkMissingOptions = (options = {}, ...requiredFields) => {
+    const missing = requiredFields.filter((requiredField) => {
+        return !_.get(options, requiredField);
+    });
+
+    if (missing.length) {
+        throw new IncorrectUsageError({
+            message: `Missing options: ${missing.join(', ')}`
+        });
+    }
+};
+
+module.exports.getFinalChangelog = function getFinalChangelog(options) {
+    let filterEmojiCommits = true;
+    let changelog = fs.readFileSync(options.changelogPath).toString('utf8').split(os.EOL);
+    let finalChangelog = [];
+
+    if (Object.prototype.hasOwnProperty.call(options, 'filterEmojiCommits')) {
+        filterEmojiCommits = options.filterEmojiCommits;
+    }
+    // @NOTE: optional array of string lines, which we pre-pend
+    if (Object.prototype.hasOwnProperty.call(options, 'content') && _.isArray(options.content)) {
+        finalChangelog = finalChangelog.concat(options.content);
+    }
+
+    if (filterEmojiCommits) {
+        changelog = module.exports.filterEmojiCommits(changelog);
+        module.exports.sortByEmoji(changelog);
+    }
+
+    if (_.isEmpty(changelog)) {
+        changelog = ['This release contains fixes for minor bugs and issues reported by Ghost users.'];
+    }
+
+    finalChangelog = finalChangelog.concat(changelog);
+    return finalChangelog;
+};

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@tryghost/release-utils",
+  "version": "0.8.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/SDK.git",
+    "directory": "packages/release-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/TryGhost/SDK/issues"
+  },
+  "homepage": "https://ghost.org",
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test": "NODE_ENV=testing c8 --all --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "lint": "eslint . --ext .js --cache",
+    "posttest": "yarn lint"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "c8": "8.0.1",
+    "mocha": "10.8.2",
+    "should": "13.2.3",
+    "sinon": "15.2.0"
+  },
+  "dependencies": {
+    "@tryghost/errors": "^1.2.1",
+    "bluebird": "^3.7.2",
+    "emoji-regex": "^10.0.0",
+    "execa": "^4.1.0",
+    "lodash": "^4.17.21",
+    "request": "^2.88.2",
+    "request-promise": "^4.2.6"
+  }
+}

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "c8": "8.0.1",
     "mocha": "10.8.2",
+    "nock": "13.5.6",
     "should": "13.2.3",
     "sinon": "15.2.0"
   },

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -34,11 +34,9 @@
   },
   "dependencies": {
     "@tryghost/errors": "^1.2.1",
-    "bluebird": "^3.7.2",
+    "axios": "1.18.1",
     "emoji-regex": "^10.0.0",
     "execa": "^4.1.0",
-    "lodash": "^4.17.21",
-    "request": "^2.88.2",
-    "request-promise": "^4.2.6"
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/release-utils/test/.eslintrc.js
+++ b/packages/release-utils/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/packages/release-utils/test/changelog.test.js
+++ b/packages/release-utils/test/changelog.test.js
@@ -1,0 +1,31 @@
+require('./utils');
+
+const fs = require('fs');
+const path = require('path');
+const {Changelog} = require('../lib');
+
+describe('Changelog', function () {
+    it('can generate changelog.md', function () {
+        const changelogPath = path.join(process.cwd(), 'changelog.md');
+
+        const changelog = new Changelog({
+            changelogPath: changelogPath,
+            folder: process.cwd()
+        });
+
+        changelog
+            .write({
+                githubRepoPath: `https://github.com/TryGhost/SDK`,
+                lastVersion: '@tryghost/release-utils@0.6.3'
+            })
+            .sort()
+            .clean();
+
+        try {
+            fs.unlinkSync(changelogPath);
+            fs.unlinkSync(changelogPath + '.bk');
+        } catch (err) {
+            should.not.exist(err);
+        }
+    });
+});

--- a/packages/release-utils/test/changelog.test.js
+++ b/packages/release-utils/test/changelog.test.js
@@ -5,6 +5,30 @@ const path = require('path');
 const {Changelog} = require('../lib');
 
 describe('Changelog', function () {
+    it('throws when required constructor options are missing', function () {
+        try {
+            /* eslint-disable no-new */
+            new Changelog();
+            throw new Error('should have thrown');
+        } catch (err) {
+            err.message.should.eql('Missing options: folder, changelogPath');
+        }
+    });
+
+    it('throws when required write options are missing', function () {
+        const changelog = new Changelog({
+            changelogPath: path.join(process.cwd(), 'changelog.md'),
+            folder: process.cwd()
+        });
+
+        try {
+            changelog.write({});
+            throw new Error('should have thrown');
+        } catch (err) {
+            err.message.should.eql('Missing options: githubRepoPath, lastVersion');
+        }
+    });
+
     it('can generate changelog.md', function () {
         const changelogPath = path.join(process.cwd(), 'changelog.md');
 
@@ -17,6 +41,35 @@ describe('Changelog', function () {
             .write({
                 githubRepoPath: `https://github.com/TryGhost/SDK`,
                 lastVersion: '@tryghost/release-utils@0.6.3'
+            })
+            .sort()
+            .clean();
+
+        try {
+            fs.unlinkSync(changelogPath);
+            fs.unlinkSync(changelogPath + '.bk');
+        } catch (err) {
+            should.not.exist(err);
+        }
+    });
+
+    it('can append to an existing changelog', function () {
+        const changelogPath = path.join(process.cwd(), 'changelog.md');
+
+        const changelog = new Changelog({
+            changelogPath: changelogPath,
+            folder: process.cwd()
+        });
+
+        changelog
+            .write({
+                githubRepoPath: `https://github.com/TryGhost/SDK`,
+                lastVersion: '@tryghost/release-utils@0.6.3'
+            })
+            .write({
+                githubRepoPath: `https://github.com/TryGhost/SDK`,
+                lastVersion: '@tryghost/release-utils@0.6.3',
+                append: true
             })
             .sort()
             .clean();

--- a/packages/release-utils/test/fixtures/changelog-no-emoji.md
+++ b/packages/release-utils/test/fixtures/changelog-no-emoji.md
@@ -1,0 +1,1 @@
+1546300800 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 1.0.0 - Author

--- a/packages/release-utils/test/fixtures/changelog.md
+++ b/packages/release-utils/test/fixtures/changelog.md
@@ -1,0 +1,3 @@
+1546300800 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) ✨ Added a shiny new feature - Author
+1546300800 * [a1b2c3d4e](https://github.com/TryGhost/Ghost/commit/a1b2c3d4e) 🐛 Fixed an annoying bug - Author
+1546300800 * [b2c3d4e5f](https://github.com/TryGhost/Ghost/commit/b2c3d4e5f) Version bump to 1.0.0 - Author

--- a/packages/release-utils/test/fixtures/release.zip
+++ b/packages/release-utils/test/fixtures/release.zip
@@ -1,0 +1,1 @@
+PK fake zip contents for upload test

--- a/packages/release-utils/test/gist.test.js
+++ b/packages/release-utils/test/gist.test.js
@@ -1,0 +1,73 @@
+require('./utils');
+
+const path = require('path');
+const nock = require('nock');
+const lib = require('../lib');
+
+const CHANGELOG = path.join(__dirname, 'fixtures', 'changelog.md');
+
+describe('Gist', function () {
+    before(function () {
+        nock.disableNetConnect();
+    });
+
+    after(function () {
+        nock.enableNetConnect();
+    });
+
+    afterEach(function () {
+        nock.cleanAll();
+    });
+
+    describe('create', function () {
+        it('throws when required options are missing', function (done) {
+            try {
+                lib.gist.create();
+            } catch (err) {
+                err.message.should.eql('Missing options: changelogPath, gistName, gistDescription, github, github.token, userAgent');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('creates a public gist and returns its url', function () {
+            const scope = nock('https://api.github.com')
+                .post('/gists', (body) => {
+                    return body.public === true;
+                })
+                .reply(201, {html_url: 'https://gist.github.com/abc123'});
+
+            return lib.gist.create({
+                changelogPath: CHANGELOG,
+                gistName: 'changelog.md',
+                gistDescription: 'Ghost changelog',
+                github: {token: 'foo'},
+                userAgent: 'Ghost'
+            }).then((result) => {
+                result.should.eql({gistUrl: 'https://gist.github.com/abc123'});
+                scope.done();
+            });
+        });
+
+        it('honours isPublic: false', function () {
+            const scope = nock('https://api.github.com')
+                .post('/gists', (body) => {
+                    return body.public === false;
+                })
+                .reply(201, {html_url: 'https://gist.github.com/secret'});
+
+            return lib.gist.create({
+                changelogPath: CHANGELOG,
+                gistName: 'changelog.md',
+                gistDescription: 'Ghost changelog',
+                github: {token: 'foo'},
+                userAgent: 'Ghost',
+                isPublic: false
+            }).then((result) => {
+                result.should.eql({gistUrl: 'https://gist.github.com/secret'});
+                scope.done();
+            });
+        });
+    });
+});

--- a/packages/release-utils/test/releases.test.js
+++ b/packages/release-utils/test/releases.test.js
@@ -1,0 +1,31 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const lib = require('../lib');
+
+describe('Releases', function () {
+    describe('uploadZip', function () {
+        it('no options', function (done) {
+            try {
+                lib.releases.uploadZip();
+            } catch (err) {
+                err.message.should.eql('Missing options: zipPath, github, github.token, userAgent, uri');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('missing options', function (done) {
+            try {
+                lib.releases.uploadZip({zipPath: 'test', github: {}});
+            } catch (err) {
+                err.message.should.eql('Missing options: github.token, userAgent, uri');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+    });
+});

--- a/packages/release-utils/test/releases.test.js
+++ b/packages/release-utils/test/releases.test.js
@@ -2,9 +2,103 @@
 // const testUtils = require('./utils');
 require('./utils');
 
+const path = require('path');
+const nock = require('nock');
 const lib = require('../lib');
 
+const CHANGELOG = path.join(__dirname, 'fixtures', 'changelog.md');
+const ZIP = path.join(__dirname, 'fixtures', 'release.zip');
+
+const RELEASES_URI = 'https://api.github.com/repos/TryGhost/Ghost/releases';
+
 describe('Releases', function () {
+    before(function () {
+        nock.disableNetConnect();
+    });
+
+    after(function () {
+        nock.enableNetConnect();
+    });
+
+    afterEach(function () {
+        nock.cleanAll();
+    });
+
+    describe('create', function () {
+        it('throws when required options are missing', function (done) {
+            try {
+                lib.releases.create();
+            } catch (err) {
+                err.message.should.eql('Missing options: changelogPath, github, github.token, userAgent, uri, tagName, releaseName');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('creates a draft release from a single changelog path', function () {
+            let sentBody;
+            const scope = nock('https://api.github.com')
+                .post('/repos/TryGhost/Ghost/releases', (body) => {
+                    sentBody = body;
+                    return true;
+                })
+                .reply(201, {id: 1, html_url: 'https://github.com/release/1', upload_url: 'https://uploads/1'});
+
+            return lib.releases.create({
+                changelogPath: CHANGELOG,
+                github: {token: 'foo'},
+                userAgent: 'Ghost',
+                uri: RELEASES_URI,
+                tagName: 'v1.0.0',
+                releaseName: '1.0.0'
+            }).then((result) => {
+                result.should.eql({
+                    id: 1,
+                    releaseUrl: 'https://github.com/release/1',
+                    uploadUrl: 'https://uploads/1'
+                });
+                // defaults
+                sentBody.draft.should.eql(true);
+                sentBody.prerelease.should.eql(false);
+                sentBody.target_commitish.should.eql('main');
+                scope.done();
+            });
+        });
+
+        it('supports an array of changelog paths, gistUrl, extraText & option overrides', function () {
+            let sentBody;
+            const scope = nock('https://api.github.com')
+                .post('/repos/TryGhost/Ghost/releases', (body) => {
+                    sentBody = body;
+                    return true;
+                })
+                .reply(201, {id: 2, html_url: 'https://github.com/release/2', upload_url: 'https://uploads/2'});
+
+            return lib.releases.create({
+                changelogPath: [{changelogPath: CHANGELOG}, {changelogPath: CHANGELOG}],
+                github: {token: 'foo'},
+                userAgent: 'Ghost',
+                uri: RELEASES_URI,
+                tagName: 'v2.0.0',
+                releaseName: '2.0.0',
+                gistUrl: 'https://gist.github.com/abc123',
+                extraText: 'Thanks to all contributors!',
+                draft: false,
+                prerelease: true,
+                targetRef: 'release-2.0'
+            }).then((result) => {
+                result.id.should.eql(2);
+                sentBody.draft.should.eql(false);
+                sentBody.prerelease.should.eql(true);
+                sentBody.target_commitish.should.eql('release-2.0');
+                sentBody.body.should.match(/full change log/);
+                sentBody.body.should.match(/Thanks to all contributors!/);
+                scope.done();
+            });
+        });
+    });
+
     describe('uploadZip', function () {
         it('no options', function (done) {
             try {
@@ -26,6 +120,67 @@ describe('Releases', function () {
             }
 
             throw new Error('should fail');
+        });
+
+        it('uploads the zip and resolves with the download url', function () {
+            const scope = nock('https://uploads.github.com')
+                .post('/repos/TryGhost/Ghost/releases/1/assets')
+                .reply(201, {browser_download_url: 'https://github.com/download/release.zip'});
+
+            return lib.releases.uploadZip({
+                zipPath: ZIP,
+                github: {token: 'foo'},
+                userAgent: 'Ghost',
+                uri: 'https://uploads.github.com/repos/TryGhost/Ghost/releases/1/assets'
+            }).then((result) => {
+                result.should.eql({downloadUrl: 'https://github.com/download/release.zip'});
+                scope.done();
+            });
+        });
+
+        it('rejects when the upload request errors', function () {
+            const scope = nock('https://uploads.github.com')
+                .post('/repos/TryGhost/Ghost/releases/1/assets')
+                .replyWithError('network boom');
+
+            return lib.releases.uploadZip({
+                zipPath: ZIP,
+                github: {token: 'foo'},
+                userAgent: 'Ghost',
+                uri: 'https://uploads.github.com/repos/TryGhost/Ghost/releases/1/assets'
+            }).then(() => {
+                throw new Error('should have rejected');
+            }).catch((err) => {
+                err.message.should.match(/network boom/);
+                scope.done();
+            });
+        });
+    });
+
+    describe('get', function () {
+        it('throws when required options are missing', function (done) {
+            try {
+                lib.releases.get();
+            } catch (err) {
+                err.message.should.eql('Missing options: userAgent, uri');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('fetches and returns the release payload', function () {
+            const scope = nock('https://api.github.com')
+                .get('/repos/TryGhost/Ghost/releases/latest')
+                .reply(200, {tag_name: 'v1.0.0'});
+
+            return lib.releases.get({
+                userAgent: 'Ghost',
+                uri: 'https://api.github.com/repos/TryGhost/Ghost/releases/latest'
+            }).then((response) => {
+                response.tag_name.should.eql('v1.0.0');
+                scope.done();
+            });
         });
     });
 });

--- a/packages/release-utils/test/utils.test.js
+++ b/packages/release-utils/test/utils.test.js
@@ -1,0 +1,37 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const lib = require('../lib');
+
+describe('Utils', function () {
+    describe('filterEmojiCommits', function () {
+        it('no emoji commits found', function () {
+            const result = lib.utils.filterEmojiCommits([
+                '1234567890 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
+                '1234567890 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name'
+            ]);
+
+            result.length.should.eql(0);
+        });
+
+        it('emoji commits found', function () {
+            const result = lib.utils.filterEmojiCommits([
+                '1234567890 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
+                '1234567890 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) 👻 Version bump to 2.17.1 - Name'
+            ]);
+
+            result.length.should.eql(1);
+        });
+
+        it('emoji commits found: just another format', function () {
+            const result = lib.utils.filterEmojiCommits([
+                '* [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
+                '* [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) 👻 Version bump to 2.17.1 - Name',
+                '* [e456ae2](https://github.com/kirrg001/testing/commit/e456ae2) 🐝 tzZZ - kirrg001'
+            ]);
+
+            result.length.should.eql(2);
+        });
+    });
+});

--- a/packages/release-utils/test/utils.test.js
+++ b/packages/release-utils/test/utils.test.js
@@ -2,10 +2,23 @@
 // const testUtils = require('./utils');
 require('./utils');
 
+const path = require('path');
 const lib = require('../lib');
+
+const CHANGELOG = path.join(__dirname, 'fixtures', 'changelog.md');
+const CHANGELOG_NO_EMOJI = path.join(__dirname, 'fixtures', 'changelog-no-emoji.md');
 
 describe('Utils', function () {
     describe('filterEmojiCommits', function () {
+        it('throws when passed a non-array', function () {
+            try {
+                lib.utils.filterEmojiCommits('not an array');
+                throw new Error('should have thrown');
+            } catch (err) {
+                err.message.should.eql('Expected array of strings.');
+            }
+        });
+
         it('no emoji commits found', function () {
             const result = lib.utils.filterEmojiCommits([
                 '1234567890 * [f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
@@ -32,6 +45,86 @@ describe('Utils', function () {
             ]);
 
             result.length.should.eql(2);
+        });
+    });
+
+    describe('sortByEmoji', function () {
+        it('throws when passed a non-array', function () {
+            try {
+                lib.utils.sortByEmoji('not an array');
+                throw new Error('should have thrown');
+            } catch (err) {
+                err.message.should.eql('Expected array of strings.');
+            }
+        });
+
+        it('sorts lines by the configured emoji order', function () {
+            const content = [
+                '* 🔒 Patched a security issue',
+                '* 💡 Introduced an idea',
+                '* 🐛 Fixed a bug'
+            ];
+
+            lib.utils.sortByEmoji(content);
+
+            // The comparator sorts by descending emojiOrder index, so the emoji
+            // that appears last in emojiOrder (🔒) sorts first and 💡 sorts last
+            content[0].should.startWith('* 🔒');
+            content[content.length - 1].should.startWith('* 💡');
+        });
+    });
+
+    describe('checkMissingOptions', function () {
+        it('does not throw when all required fields are present', function () {
+            lib.utils.checkMissingOptions({a: 1, b: {c: 2}}, 'a', 'b.c');
+        });
+
+        it('throws listing every missing field', function () {
+            try {
+                lib.utils.checkMissingOptions({a: 1}, 'a', 'b', 'c');
+                throw new Error('should have thrown');
+            } catch (err) {
+                err.message.should.eql('Missing options: b, c');
+            }
+        });
+    });
+
+    describe('getFinalChangelog', function () {
+        it('returns the filtered & sorted emoji commits by default', function () {
+            const result = lib.utils.getFinalChangelog({changelogPath: CHANGELOG});
+
+            // Only the two emoji commits survive, sorted by descending emojiOrder
+            // index (✨ appears later in emojiOrder than 🐛, so it sorts first)
+            result.length.should.eql(2);
+            result[0].should.startWith('* ✨');
+            result[1].should.startWith('* 🐛');
+        });
+
+        it('prepends optional content lines', function () {
+            const result = lib.utils.getFinalChangelog({
+                changelogPath: CHANGELOG,
+                content: ['# Heading', '']
+            });
+
+            result[0].should.eql('# Heading');
+            result[1].should.eql('');
+            result.length.should.eql(4);
+        });
+
+        it('keeps the raw changelog when filterEmojiCommits is false', function () {
+            const result = lib.utils.getFinalChangelog({
+                changelogPath: CHANGELOG,
+                filterEmojiCommits: false
+            });
+
+            // No filtering: all three (non-empty) lines are retained
+            result.filter(Boolean).length.should.eql(3);
+        });
+
+        it('falls back to a default message when nothing remains', function () {
+            const result = lib.utils.getFinalChangelog({changelogPath: CHANGELOG_NO_EMOJI});
+
+            result.should.eql(['This release contains fixes for minor bugs and issues reported by Ghost users.']);
         });
     });
 });

--- a/packages/release-utils/test/utils/assertions.js
+++ b/packages/release-utils/test/utils/assertions.js
@@ -1,0 +1,11 @@
+/**
+ * Custom Should Assertions
+ *
+ * Add any custom assertions to this file.
+ */
+
+// Example Assertion
+// should.Assertion.add('ExampleAssertion', function () {
+//     this.params = {operator: 'to be a valid Example Assertion'};
+//     this.obj.should.be.an.Object;
+// });

--- a/packages/release-utils/test/utils/index.js
+++ b/packages/release-utils/test/utils/index.js
@@ -1,0 +1,11 @@
+/**
+ * Test Utilities
+ *
+ * Shared utils for writing tests
+ */
+
+// Require overrides - these add globals for tests
+require('./overrides');
+
+// Require assertions - adds custom should assertions
+require('./assertions');

--- a/packages/release-utils/test/utils/overrides.js
+++ b/packages/release-utils/test/utils/overrides.js
@@ -1,0 +1,10 @@
+// This file is required before any test is run
+
+// Taken from the should wiki, this is how to make should global
+// Should is a global in our eslint test config
+global.should = require('should').noConflict();
+should.extend();
+
+// Sinon is a simple case
+// Sinon is a global in our eslint test config
+global.sinon = require('sinon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,7 +4287,7 @@ ajv@8.20.0, ajv@^8.0.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-ajv@^6.12.3, ajv@^6.12.4, ajv@^6.14.0:
+ajv@^6.12.4, ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
   integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
@@ -4452,18 +4452,6 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
-asn1@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
-  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
-  dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -4499,16 +4487,6 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
-
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
-
-aws4@^1.8.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
-  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
 axios@1.16.0:
   version "1.16.0"
@@ -4583,13 +4561,6 @@ baseline-browser-mapping@^2.10.12:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
   integrity sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==
 
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
-  dependencies:
-    tweetnacl "^0.14.3"
-
 before-after-hook@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
@@ -4627,7 +4598,7 @@ bl@4.1.0, bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.5.0, bluebird@^3.7.2:
+bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4841,11 +4812,6 @@ caniuse-lite@^1.0.30001782:
   version "1.0.30001799"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
   integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 ccount@^1.0.0:
   version "1.1.0"
@@ -5106,7 +5072,7 @@ columnify@1.6.0:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
-combined-stream@1.0.8, combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@1.0.8, combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -5283,11 +5249,6 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
-
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -5360,13 +5321,6 @@ dargs@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
-  dependencies:
-    assert-plus "^1.0.0"
 
 data-urls@^7.0.0:
   version "7.0.0"
@@ -5656,14 +5610,6 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
@@ -6380,20 +6326,10 @@ exsolve@^1.0.8:
   resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.8.tgz#7f5e34da61cd1116deda5136e62292c096f50613"
   integrity sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -6542,11 +6478,6 @@ foreground-child@^3.1.0, foreground-child@^3.1.1, foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
 form-data@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
@@ -6568,15 +6499,6 @@ form-data@4.0.6, form-data@^4.0.5:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.4"
     mime-types "^2.1.35"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
 
 fs-constants@1.0.0, fs-constants@^1.0.0:
   version "1.0.0"
@@ -6780,13 +6702,6 @@ get-tsconfig@^4.8.1:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
-  dependencies:
-    assert-plus "^1.0.0"
-
 git-raw-commits@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-3.0.0.tgz#5432f053a9744f67e8db03dbc48add81252cfdeb"
@@ -6989,19 +6904,6 @@ handlebars@4.7.9, handlebars@^4.0.1, handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
 hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
@@ -7164,15 +7066,6 @@ http-proxy-agent@^7.0.0:
   dependencies:
     agent-base "^7.1.0"
     debug "^4.3.4"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -7655,7 +7548,7 @@ is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
   dependencies:
     which-typed-array "^1.1.16"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
@@ -7726,11 +7619,6 @@ isexe@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-4.0.0.tgz#48f6576af8e87a18feb796b7ed5e2e5903b43dca"
   integrity sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
@@ -7844,11 +7732,6 @@ js-yaml@^4.1.0, js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
-
 jsdom@29.1.1:
   version "29.1.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
@@ -7916,11 +7799,6 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -7931,7 +7809,7 @@ json-stringify-nice@^1.1.4:
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -7975,16 +7853,6 @@ jsonwebtoken@9.0.3:
     lodash.once "^4.0.0"
     ms "^2.1.1"
     semver "^7.5.4"
-
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.4.0"
-    verror "1.10.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -8393,7 +8261,7 @@ lodash@4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@4.18.1, lodash@^4.17.19, lodash@^4.17.21:
+lodash@4.18.1, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -8621,7 +8489,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19:
+mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9336,11 +9204,6 @@ nth-check@^2.0.1:
     "@nx/nx-win32-arm64-msvc" "22.7.5"
     "@nx/nx-win32-x64-msvc" "22.7.5"
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -9810,11 +9673,6 @@ peek-readable@^4.1.0:
   resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
   integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
-
 picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -10005,13 +9863,6 @@ proxy-from-env@2.1.0, proxy-from-env@^2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
-psl@^1.1.28:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
-  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
-  dependencies:
-    punycode "^2.3.1"
-
 pump@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
@@ -10028,15 +9879,10 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
+punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-qs@~6.5.2:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.5.tgz#7c9442fc3f1c58bb52ac57ad09db63ba68916395"
-  integrity sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==
 
 quansync@^0.2.11:
   version "0.2.11"
@@ -10348,49 +10194,6 @@ repeat-string@^1.5.4:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-request-promise-core@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
-  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  dependencies:
-    lodash "^4.17.19"
-
-request-promise@^4.2.6:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.88.2:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 require-directory@2.1.1, require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -10612,7 +10415,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -10646,7 +10449,7 @@ safe-regex@^2.1.1:
   dependencies:
     regexp-tree "~0.1.1"
 
-"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -11058,21 +10861,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sshpk@^1.7.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
-  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
-
 ssri@12.0.0, ssri@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-12.0.0.tgz#bcb4258417c702472f8191981d3c8a771fee6832"
@@ -11101,11 +10889,6 @@ std-env@^4.0.0-rc.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
   integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
-
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -11476,14 +11259,6 @@ token-types@^4.1.1:
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
-tough-cookie@^2.3.3, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tough-cookie@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
@@ -11581,18 +11356,6 @@ tuf-js@^4.1.0:
     "@tufjs/models" "4.1.0"
     debug "^4.4.3"
     make-fetch-happen "^15.0.1"
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -11918,11 +11681,6 @@ uuid@^13.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.2.tgz#41bc9c07b12f665089c205f6507976adbdf84ff8"
   integrity sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
 uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
@@ -11959,15 +11717,6 @@ validate-npm-package-name@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz#e57c3d721a4c8bbff454a246e7f7da811559ea0d"
   integrity sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 vfile-location@^2.0.0:
   version "2.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,6 +3679,14 @@
     "@stdlib/utils-copy" "^0.2.0"
     uuid "^13.0.0"
 
+"@tryghost/errors@^1.2.1":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.13.tgz#e604160bd5a4b26b6c30cdc82dad22d9ce892dce"
+  integrity sha512-sXFcuU8Nn3mDcVrLBLFThQZImn+T2w7v/jJGJzdFnSKJstqxd1LyTRlMjpCpgCnqAgHFCaP+uFg7x4CX64VBJQ==
+  dependencies:
+    "@stdlib/utils-copy" "^0.2.0"
+    uuid "^9.0.0"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.12.tgz#be57ceac1e4692b41be9de6be8c32a106636dba4"
@@ -4279,7 +4287,7 @@ ajv@8.20.0, ajv@^8.0.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-ajv@^6.12.4, ajv@^6.14.0:
+ajv@^6.12.3, ajv@^6.12.4, ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
   integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
@@ -4444,6 +4452,18 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
+asn1@~0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -4479,6 +4499,16 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
+
+aws4@^1.8.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
+  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
 axios@1.16.0:
   version "1.16.0"
@@ -4553,6 +4583,13 @@ baseline-browser-mapping@^2.10.12:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
   integrity sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==
 
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
+  dependencies:
+    tweetnacl "^0.14.3"
+
 before-after-hook@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
@@ -4590,7 +4627,7 @@ bl@4.1.0, bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.7.2:
+bluebird@^3.5.0, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4804,6 +4841,11 @@ caniuse-lite@^1.0.30001782:
   version "1.0.30001799"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
   integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 ccount@^1.0.0:
   version "1.1.0"
@@ -5064,7 +5106,7 @@ columnify@1.6.0:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
-combined-stream@1.0.8, combined-stream@^1.0.8:
+combined-stream@1.0.8, combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -5241,6 +5283,11 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -5313,6 +5360,13 @@ dargs@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+  dependencies:
+    assert-plus "^1.0.0"
 
 data-urls@^7.0.0:
   version "7.0.0"
@@ -5603,6 +5657,14 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
@@ -5643,6 +5705,11 @@ emoji-regex@8.0.0, emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^10.0.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 emoji-regex@^9.2.2:
   version "9.2.2"
@@ -6283,6 +6350,21 @@ execa@5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execa@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 expect-type@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
@@ -6298,10 +6380,20 @@ exsolve@^1.0.8:
   resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.8.tgz#7f5e34da61cd1116deda5136e62292c096f50613"
   integrity sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==
 
-extend@^3.0.0:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -6450,6 +6542,11 @@ foreground-child@^3.1.0, foreground-child@^3.1.1, foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
 form-data@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
@@ -6471,6 +6568,15 @@ form-data@4.0.6, form-data@^4.0.5:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.4"
     mime-types "^2.1.35"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 fs-constants@1.0.0, fs-constants@^1.0.0:
   version "1.0.0"
@@ -6646,7 +6752,7 @@ get-stream@6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
   integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
-get-stream@^5.1.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
@@ -6673,6 +6779,13 @@ get-tsconfig@^4.8.1:
   integrity sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==
   dependencies:
     resolve-pkg-maps "^1.0.0"
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
+  dependencies:
+    assert-plus "^1.0.0"
 
 git-raw-commits@^3.0.0:
   version "3.0.0"
@@ -6876,6 +6989,19 @@ handlebars@4.7.9, handlebars@^4.0.1, handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
+
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
+
 hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
@@ -7039,6 +7165,15 @@ http-proxy-agent@^7.0.0:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
@@ -7062,6 +7197,11 @@ https-proxy-agent@^7.0.1:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -7515,7 +7655,7 @@ is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
   dependencies:
     which-typed-array "^1.1.16"
 
-is-typedarray@^1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
@@ -7586,6 +7726,11 @@ isexe@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-4.0.0.tgz#48f6576af8e87a18feb796b7ed5e2e5903b43dca"
   integrity sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
@@ -7699,6 +7844,11 @@ js-yaml@^4.1.0, js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
 jsdom@29.1.1:
   version "29.1.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
@@ -7766,6 +7916,11 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -7776,7 +7931,7 @@ json-stringify-nice@^1.1.4:
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
   integrity sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==
 
-json-stringify-safe@^5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -7820,6 +7975,16 @@ jsonwebtoken@9.0.3:
     lodash.once "^4.0.0"
     ms "^2.1.1"
     semver "^7.5.4"
+
+jsprim@^1.2.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
+    verror "1.10.0"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -8228,7 +8393,7 @@ lodash@4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodash@4.18.1, lodash@^4.17.21:
+lodash@4.18.1, lodash@^4.17.19, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -8456,7 +8621,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.35:
+mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9021,7 +9186,7 @@ npm-registry-fetch@^19.0.0:
     npm-package-arg "^13.0.0"
     proc-log "^6.0.0"
 
-npm-run-path@4.0.1, npm-run-path@^4.0.1:
+npm-run-path@4.0.1, npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -9161,6 +9326,11 @@ nth-check@^2.0.1:
     "@nx/nx-linux-x64-musl" "22.7.5"
     "@nx/nx-win32-arm64-msvc" "22.7.5"
     "@nx/nx-win32-x64-msvc" "22.7.5"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -9631,6 +9801,11 @@ peek-readable@^4.1.0:
   resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
   integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
 picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -9816,6 +9991,13 @@ proxy-from-env@2.1.0, proxy-from-env@^2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
+psl@^1.1.28:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
 pump@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
@@ -9832,10 +10014,15 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.3.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+qs@~6.5.2:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.5.tgz#7c9442fc3f1c58bb52ac57ad09db63ba68916395"
+  integrity sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==
 
 quansync@^0.2.11:
   version "0.2.11"
@@ -10147,6 +10334,49 @@ repeat-string@^1.5.4:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
+request-promise-core@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
+  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
+  dependencies:
+    lodash "^4.17.19"
+
+request-promise@^4.2.6:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
+  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.4"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request@^2.88.2:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@2.1.1, require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -10368,7 +10598,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -10402,7 +10632,7 @@ safe-regex@^2.1.1:
   dependencies:
     regexp-tree "~0.1.1"
 
-"safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10814,6 +11044,21 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+sshpk@^1.7.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
+  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
 ssri@12.0.0, ssri@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-12.0.0.tgz#bcb4258417c702472f8191981d3c8a771fee6832"
@@ -10842,6 +11087,11 @@ std-env@^4.0.0-rc.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
   integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -11212,6 +11462,14 @@ token-types@^4.1.1:
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tough-cookie@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
@@ -11309,6 +11567,18 @@ tuf-js@^4.1.0:
     "@tufjs/models" "4.1.0"
     debug "^4.4.3"
     make-fetch-happen "^15.0.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -11634,6 +11904,16 @@ uuid@^13.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.2.tgz#41bc9c07b12f665089c205f6507976adbdf84ff8"
   integrity sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -11665,6 +11945,15 @@ validate-npm-package-name@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz#e57c3d721a4c8bbff454a246e7f7da811559ea0d"
   integrity sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 vfile-location@^2.0.0:
   version "2.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8950,6 +8950,15 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+nock@13.5.6:
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.6.tgz#5e693ec2300bbf603b61dae6df0225673e6c4997"
+  integrity sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
+
 node-addon-api@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
@@ -9971,6 +9980,11 @@ prop-types@15.8.1, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proper-lockfile@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
This package is still used in themes, so should be in a non-archived repo in case we need to make a change.

Also added test coverage to match the existing requirement in this repo
