### PR TITLE
Added typings to adapter-base-cache package

### DIFF
--- a/packages/adapter-base-cache/index.d.ts
+++ b/packages/adapter-base-cache/index.d.ts
@@ -1,0 +1,38 @@
+export = BaseCacheAdapter;
+
+/**
+ * Base class for cache adapters.
+ *
+ * Concrete adapters should extend this class and implement the methods listed
+ * in `requiredFns`: `get`, `set`, `reset` and `keys`.
+ */
+declare abstract class BaseCacheAdapter<K = string, V = unknown> {
+    /**
+     * The list of method names a concrete cache adapter is required to implement.
+     *
+     * NOTE: the "keys" method is only here to provide a smooth migration from the
+     * deprecated "getAll" method. Once use of "getAll" is eradicated, "keys" can
+     * also be removed from the interface.
+     */
+    readonly requiredFns: ReadonlyArray<'get' | 'set' | 'reset' | 'keys'>;
+
+    /**
+     * Retrieve the value stored under the given key.
+     */
+    abstract get(key: K): unknown;
+
+    /**
+     * Store a value under the given key.
+     */
+    abstract set(key: K, value: V): unknown;
+
+    /**
+     * Clear the entire cache.
+     */
+    abstract reset(): unknown;
+
+    /**
+     * List all keys currently held in the cache.
+     */
+    abstract keys(): unknown;
+}

--- a/packages/adapter-base-cache/package.json
+++ b/packages/adapter-base-cache/package.json
@@ -9,6 +9,7 @@
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test:unit": "NODE_ENV=testing c8 --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
@@ -18,6 +19,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "lib"
   ],
   "publishConfig": {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-231
- add a basic typings file to adapter-base-cache to allow typescript type hints