### PR TITLE
Add contrast color regression coverage

### DIFF
--- a/packages/color-utils/test/color-utils.test.js
+++ b/packages/color-utils/test/color-utils.test.js
@@ -69,5 +69,20 @@ describe('color-utils', function () {
             const result = textColorForBackgroundColor('#333333');
             assert.equal(result.hex(), '#FFFFFF');
         });
+
+        const additionalColorCases = [
+            {background: '#dacafe', expected: '#000000', description: 'reported lavender background'},
+            {background: '#ffa5b1', expected: '#000000', description: 'reported pink background'},
+            {background: '#a3e6ff', expected: '#000000', description: 'reported blue background'},
+            {background: '#b9b9b9', expected: '#FFFFFF', description: 'gray below the YIQ threshold'},
+            {background: '#bbbbbb', expected: '#000000', description: 'gray above the YIQ threshold'}
+        ];
+
+        for (const {background, expected, description} of additionalColorCases) {
+            it(`returns ${expected === '#000000' ? 'black' : 'white'} for a ${description}`, function () {
+                const result = textColorForBackgroundColor(background);
+                assert.equal(result.hex(), expected);
+            });
+        }
     });
 });


### PR DESCRIPTION
## Summary

Adds five independent regression cases for `textColorForBackgroundColor` following #1031. This is a tests-only change: all existing assertions remain intact and no production or generated files change.

## Coverage

- Adds the three exact light backgrounds reported in TryGhost/Ghost#27797: `#dacafe`, `#ffa5b1`, and `#a3e6ff`.
- Adds `#b9b9b9` and `#bbbbbb` to cover the white/black decision immediately below and above the YIQ threshold.
- Keeps the existing `#cccccc` RGB blue-channel regression unchanged.

A deliberate check using the previous `Color.b()` calculation fails four of the five added cases, confirming the new cases protect the visual correction in #1031.

## Validation

- `yarn workspace @tryghost/color-utils build`
- `yarn workspace @tryghost/color-utils test` — 16 tests passed, 100% coverage
- `yarn test` — SDK-wide lint and tests passed across all 17 projects
- `git diff --check`

Refs #1031 and TryGhost/Ghost#27797.